### PR TITLE
Capture func invocation in Volt

### DIFF
--- a/scripts/update_voltdb_procedures.sh
+++ b/scripts/update_voltdb_procedures.sh
@@ -3,12 +3,23 @@ set -ex
 
 SCRIPT_DIR=$(dirname $(readlink -f $0))
 # Enter the root dir of the repo.
-cd ${SCRIPT_DIR}/../
 
 VOLTDB_BIN="${VOLT_HOME}/bin"
 
+cd ${SCRIPT_DIR}/../
+
+# Test if Vertica JDBC is downloaded.
+if [[ ! -f target/vertica/vertica-jdbc-10.1.1-0.jar ]]; then
+    mkdir -p target/vertica
+    cd target/vertica
+    curl -LJO https://storage.googleapis.com/apiary_public/vertica-jdbc-10.1.1-0.jar
+    jar xf vertica-jdbc-10.1.1-0.jar
+fi
+
+cd ${SCRIPT_DIR}/../
 mvn -DskipTests package
 
-javac -cp "$VOLT_HOME/voltdb/*:$PWD/target/*" -d obj/sql $(find src/main/java/org/dbos/apiary/procedures/voltdb -type f -name *.java)
-jar cvf target/DBOSProcedures.jar -C obj/sql . -C target/classes org/dbos/apiary/interposition -C target/classes org/dbos/apiary/voltdb -C target/classes org/dbos/apiary/executor -C target/classes org/dbos/apiary/utilities
+javac -cp "$VOLT_HOME/voltdb/*:$PWD/target/*:$PWD/target/vertica/*" -d obj/sql $(find src/main/java/org/dbos/apiary/procedures/voltdb -type f -name *.java)
+jar cvf target/DBOSProcedures.jar -C obj/sql . -C target/classes org/dbos/apiary/interposition -C target/classes org/dbos/apiary/voltdb -C target/classes org/dbos/apiary/executor -C target/classes org/dbos/apiary/utilities  -C  target/vertica .
+
 ${VOLTDB_BIN}/sqlcmd < sql/load_procedures.sql

--- a/src/main/java/org/dbos/apiary/interposition/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/interposition/ProvenanceBuffer.java
@@ -36,6 +36,7 @@ public class ProvenanceBuffer {
         }
     }
 
+    // TODO: need a better way to auto-reconnect to Vertica, during transient failures.
     public final ThreadLocal<Connection> conn;
 
     public final Boolean hasConnection;
@@ -146,6 +147,10 @@ public class ProvenanceBuffer {
 
     private void exportTableBuffer(String table) throws SQLException {
         Connection connection = this.conn.get();
+        if (connection == null) {
+            logger.error("Failed to get connection.");
+            return;
+        }
         TableBuffer tableBuffer = tableBufferMap.get(table);
         PreparedStatement pstmt = connection.prepareStatement(tableBuffer.preparedQuery);
         int numEntries = tableBuffer.bufferEntryQueue.size();

--- a/src/main/java/org/dbos/apiary/utilities/ApiaryConfig.java
+++ b/src/main/java/org/dbos/apiary/utilities/ApiaryConfig.java
@@ -10,4 +10,5 @@ public class ApiaryConfig {
 
     public static final Boolean captureUpdates = true;
     public static final Boolean captureReads = true;
+    public static final String olapDefaultAddress = "localhost";
 }

--- a/src/main/java/org/dbos/apiary/voltdb/VoltFunctionContext.java
+++ b/src/main/java/org/dbos/apiary/voltdb/VoltFunctionContext.java
@@ -4,6 +4,7 @@ import org.dbos.apiary.executor.FunctionOutput;
 import org.dbos.apiary.interposition.ApiaryFunction;
 import org.dbos.apiary.interposition.ApiaryFunctionContext;
 import org.dbos.apiary.interposition.ApiaryStatefulFunctionContext;
+import org.dbos.apiary.interposition.ProvenanceBuffer;
 import org.voltdb.DeprecatedProcedureAPIAccess;
 import org.voltdb.SQLStmt;
 import org.voltdb.VoltTable;
@@ -14,9 +15,9 @@ public class VoltFunctionContext extends ApiaryStatefulFunctionContext {
 
     private final VoltApiaryProcedure p;
 
-    public VoltFunctionContext(VoltApiaryProcedure p) {
+    public VoltFunctionContext(VoltApiaryProcedure p, ProvenanceBuffer provBuff, String service, long execID) {
         // TODO: add actual provenance buffer, service name, and execution ID.
-        super(null, null, 0l);
+        super(provBuff, service, execID);
         this.p = p;
     }
 

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -63,7 +63,7 @@ public class ApiaryWorker {
     public final ProvenanceBuffer provenanceBuffer;
 
     public ApiaryWorker(ApiaryConnection c, ApiaryScheduler scheduler, int numWorkerThreads) {
-        this(c, scheduler, numWorkerThreads, "localhost");
+        this(c, scheduler, numWorkerThreads, ApiaryConfig.olapDefaultAddress);
     }
 
     public ApiaryWorker(ApiaryConnection c, ApiaryScheduler scheduler, int numWorkerThreads, String olapAddress) {

--- a/src/test/java/org/dbos/apiary/BenchmarkTests.java
+++ b/src/test/java/org/dbos/apiary/BenchmarkTests.java
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory;
 import org.voltdb.client.ProcCallException;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 

--- a/src/test/java/org/dbos/apiary/PostgresTests.java
+++ b/src/test/java/org/dbos/apiary/PostgresTests.java
@@ -41,6 +41,7 @@ public class PostgresTests {
         } catch (Exception e) {
             logger.info("Failed to connect to Postgres.");
         }
+        apiaryWorker = null;
     }
 
     @AfterEach
@@ -160,7 +161,7 @@ public class PostgresTests {
 
         int res;
         int key = 10, value = 100;
-        res = client.executeFunction("localhost", "ProvenanceTestFunction", "testProvService", key, value).getInt();
+        res = client.executeFunction("localhost", "ProvenanceTestFunction", "testPostgresProvService", key, value).getInt();
         assertEquals(101, res);
 
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
@@ -168,14 +169,14 @@ public class PostgresTests {
         // Check provenance tables.
         // Check function invocation table.
         String table = "FUNCINVOCATIONS";
-        ResultSet rs = stmt.executeQuery(String.format("SELECT * FROM %s ORDER BY APIARY_EXPORT_TIMESTAMP;", table));
+        ResultSet rs = stmt.executeQuery(String.format("SELECT * FROM %s ORDER BY APIARY_EXPORT_TIMESTAMP DESC;", table));
         rs.next();
         long txid1 = rs.getLong(1);
         long resExecId = rs.getLong(3);
         String resService = rs.getString(4);
         String resFuncName = rs.getString(5);
         assertEquals(0l, resExecId);
-        assertEquals(resService, "testProvService");
+        assertEquals(resService, "testPostgresProvService");
         assertEquals(ProvenanceTestFunction.class.getName(), resFuncName);
 
         rs.next();
@@ -184,7 +185,7 @@ public class PostgresTests {
         resService = rs.getString(4);
         resFuncName = rs.getString(5);
         assertEquals(0l, resExecId);
-        assertEquals(resService, "testProvService");
+        assertEquals(resService, "testPostgresProvService");
         assertEquals(ProvenanceTestFunction.class.getName(), resFuncName);
 
         // Inner transaction should have the same transaction ID.

--- a/src/test/java/org/dbos/apiary/VoltDBTests.java
+++ b/src/test/java/org/dbos/apiary/VoltDBTests.java
@@ -1,0 +1,88 @@
+package org.dbos.apiary;
+
+import org.dbos.apiary.executor.ApiaryConnection;
+import org.dbos.apiary.interposition.ProvenanceBuffer;
+import org.dbos.apiary.procedures.voltdb.tests.AdditionFunction;
+import org.dbos.apiary.utilities.ApiaryConfig;
+import org.dbos.apiary.voltdb.VoltDBConnection;
+import org.dbos.apiary.worker.ApiaryNaiveScheduler;
+import org.dbos.apiary.worker.ApiaryWorker;
+import org.dbos.apiary.worker.ApiaryWorkerClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.voltdb.client.ProcCallException;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VoltDBTests {
+    private static final Logger logger = LoggerFactory.getLogger(VoltDBTests.class);
+
+    private ApiaryWorker apiaryWorker;
+
+    @BeforeEach
+    public void reset() throws IOException, ProcCallException {
+        VoltDBConnection ctxt = new VoltDBConnection("localhost", ApiaryConfig.voltdbPort);
+        ctxt.client.callProcedure("TruncateTables");
+        apiaryWorker = null;
+    }
+
+    @AfterEach
+    public void cleanupWorker() {
+        if (apiaryWorker != null) {
+            apiaryWorker.shutdown();
+        }
+    }
+
+    @Test
+    public void testVoltProvenance() throws IOException, SQLException, InterruptedException {
+        // TODO: implement more tests as we have read/write provenance capture.
+        logger.info("testVoltProvenance");
+        ApiaryConnection c = new VoltDBConnection("localhost", ApiaryConfig.voltdbPort);
+        apiaryWorker = new ApiaryWorker(c, new ApiaryNaiveScheduler(), 4);
+        apiaryWorker.startServing();
+
+        ProvenanceBuffer provBuff = apiaryWorker.provenanceBuffer;
+        if (provBuff == null) {
+            logger.info("Provenance buffer (Vertica) not available.");
+            return;
+        }
+
+        // Wait a bit so previous provenance capture data would be flushed out.
+        Thread.sleep(ProvenanceBuffer.exportInterval * 4);
+        Connection verticaConn = provBuff.conn.get();
+        Statement stmt = verticaConn.createStatement();
+        String[] tables = {"FUNCINVOCATIONS"};
+        for (String table : tables) {
+            stmt.execute(String.format("TRUNCATE TABLE %s;", table));
+        }
+
+        ApiaryWorkerClient client = new ApiaryWorkerClient();
+
+        String res = client.executeFunction("localhost", "AdditionFunction", "testVoltProvService", 1, "2", new String[]{"aaa", "bbb"}, new int[]{2, 3}).getString();
+        assertEquals("8aaabbb", res);
+
+        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
+
+        // Check function invocation table.
+        String table = "FUNCINVOCATIONS";
+        ResultSet rs = stmt.executeQuery(String.format("SELECT * FROM %s ORDER BY APIARY_EXPORT_TIMESTAMP;", table));
+        rs.next();
+        long txid = rs.getLong(1);
+        long resExecId = rs.getLong(3);
+        String resService = rs.getString(4);
+        String resFuncName = rs.getString(5);
+        assertTrue(txid > 0l);
+        assertEquals(0l, resExecId);
+        assertEquals(resService, "testVoltProvService");
+        assertEquals(AdditionFunction.class.getName(), resFuncName);
+    }
+}


### PR DESCRIPTION
Capture func invocation in Volt.
Compile Vertica JDBC into SP.

Maybe we can have a better solution for SP provenance capture. A few issues:
1.  If we want to update the provenance code, we have to unload all SPs and re-load them again. It would be annoying for real production.
2. It may not be a good idea to maintain Vertica connections within the SP execution space.

The best solution is to dump provenance data to some memory space and then we have a separate process to export the buffer to Vertica, outside of the Volt process.