### PR TITLE
Clean up worker and provenance code

### DIFF
--- a/src/main/java/org/dbos/apiary/client/InternalApiaryWorkerClient.java
+++ b/src/main/java/org/dbos/apiary/client/InternalApiaryWorkerClient.java
@@ -2,7 +2,6 @@ package org.dbos.apiary.client;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import jdk.jshell.execution.Util;
 import org.dbos.apiary.ExecuteFunctionReply;
 import org.dbos.apiary.ExecuteFunctionRequest;
 import org.dbos.apiary.function.FunctionOutput;

--- a/src/main/java/org/dbos/apiary/client/InternalApiaryWorkerClient.java
+++ b/src/main/java/org/dbos/apiary/client/InternalApiaryWorkerClient.java
@@ -2,6 +2,7 @@ package org.dbos.apiary.client;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import jdk.jshell.execution.Util;
 import org.dbos.apiary.ExecuteFunctionReply;
 import org.dbos.apiary.ExecuteFunctionRequest;
 import org.dbos.apiary.function.FunctionOutput;
@@ -93,16 +94,7 @@ public class InternalApiaryWorkerClient {
         socket.send(reqBytes, 0);
         byte[] replyBytes = socket.recv(0);
         ExecuteFunctionReply rep = ExecuteFunctionReply.parseFrom(replyBytes);
-        Object output = null;
-        if (rep.getReplyType() == ApiaryWorker.stringType) {
-            output = rep.getReplyString();
-        } else if (rep.getReplyType() == ApiaryWorker.intType) {
-            output = rep.getReplyInt();
-        } else if (rep.getReplyType() == ApiaryWorker.stringArrayType) {
-            output = Utilities.byteArrayToStringArray(rep.getReplyArray().toByteArray());
-        } else if (rep.getReplyType() == ApiaryWorker.intArrayType) {
-            output = Utilities.byteArrayToIntArray(rep.getReplyArray().toByteArray());
-        }
+        Object output = Utilities.getOutputFromReply(rep);
         return new FunctionOutput(output, null);
     }
 

--- a/src/main/java/org/dbos/apiary/elasticsearch/ElasticsearchConnection.java
+++ b/src/main/java/org/dbos/apiary/elasticsearch/ElasticsearchConnection.java
@@ -69,7 +69,7 @@ public class ElasticsearchConnection implements ApiaryConnection {
             this.client = new ElasticsearchClient(transport);
         } catch (CertificateException | IOException | KeyStoreException | NoSuchAlgorithmException | KeyManagementException e) {
             logger.info("Elasticsearch Connection Failed");
-            e.printStackTrace();
+            throw new RuntimeException("Failed to connect to ElasticSearch");
         }
     }
 

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -41,7 +41,7 @@ public class ProvenanceBuffer {
         }
     }
 
-    // TODO: need a better way to auto-reconnect to Vertica, during transient failures.
+    // TODO: need a better way to auto-reconnect to the remote provenance DB, during transient failures.
     public final ThreadLocal<Connection> conn;
     private final String databaseName;
 
@@ -51,6 +51,12 @@ public class ProvenanceBuffer {
 
     public ProvenanceBuffer(String databaseName, String databaseAddress) throws ClassNotFoundException {
         this.databaseName = databaseName;
+        if (databaseName == null) {
+            logger.info("No provenance buffer!");
+            this.conn = null;
+            this.hasConnection = false;
+            return;
+        }
         if (databaseName.equals(ApiaryConfig.vertica)) {
             Class.forName("com.vertica.jdbc.Driver");
             this.conn = ThreadLocal.withInitial(() -> {
@@ -95,7 +101,7 @@ public class ProvenanceBuffer {
         }
 
         if (conn.get() == null) {
-            logger.info("No Vertica instance!");
+            logger.info("No DB instance for provenance!");
             this.hasConnection = false;
             return;
         }

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -41,17 +41,11 @@ public class ApiaryWorker {
     private final ExecutorService reqThreadPool;
     private final ExecutorService repThreadPool;
     private final BlockingQueue<Runnable> reqQueue = new DispatcherPriorityQueue<>();
-    private final Set<ZContext> localContexts = ConcurrentHashMap.newKeySet();
     private final Map<String, Deque<Long>> functionRuntimesNs = new ConcurrentHashMap<>();
     private final Map<String, AtomicDouble> functionAverageRuntimesNs = new ConcurrentHashMap<>();
     private final int runningAverageLength = 100;
     private final List<Long> defaultQueue = new ArrayList<>();
     private final Long defaultTimeNs = 100000L;
-    private final ThreadLocal<InternalApiaryWorkerClient> localClients = ThreadLocal.withInitial(() -> {
-        ZContext context = ZContext.shadow(zContext);
-        localContexts.add(context);
-        return new InternalApiaryWorkerClient(context);
-    });
 
     public final WorkerContext workerContext;
 
@@ -102,7 +96,6 @@ public class ApiaryWorker {
             reqThreadPool.awaitTermination(10000, TimeUnit.SECONDS);
             repThreadPool.shutdown();
             repThreadPool.awaitTermination(10000, TimeUnit.SECONDS);
-            localContexts.forEach(ZContext::close);
             serverThread.interrupt();
             zContext.close();
             serverThread.join();
@@ -163,23 +156,8 @@ public class ApiaryWorker {
             Object finalOutput = callerTask.getFinalOutput();
             assert (finalOutput != null);
             // Send back the response only once.
-            ExecuteFunctionReply.Builder b = ExecuteFunctionReply.newBuilder()
-                    .setCallerId(callerTask.callerId)
-                    .setFunctionId(callerTask.functionID)
-                    .setSenderTimestampNano(callerTask.senderTimestampNano);
-            if (output instanceof String) {
-                b.setReplyType(stringType);
-                b.setReplyString((String) output);
-            } else if (output instanceof Integer) {
-                b.setReplyType(intType);
-                b.setReplyInt((int) output);
-            } else if (output instanceof String[]) {
-                b.setReplyType(stringArrayType);
-                b.setReplyArray(ByteString.copyFrom(Utilities.stringArraytoByteArray((String[]) output)));
-            } else if (output instanceof int[]) {
-                b.setReplyType(intArrayType);
-                b.setReplyArray(ByteString.copyFrom(Utilities.intArrayToByteArray((int[]) output)));
-            }
+            ExecuteFunctionReply.Builder b = Utilities.constructReply(callerTask.callerId, callerTask.functionID,
+                    callerTask.senderTimestampNano, finalOutput);
             outgoingReplyMsgQueue.add(new OutgoingMsg(callerTask.replyAddr, b.build().toByteArray()));
 
             // Clean up the stash map.
@@ -188,7 +166,8 @@ public class ApiaryWorker {
     }
 
     // Execute current function, push future tasks into a queue, then send back a reply if everything is finished.
-    private void executeFunction(String name, String service, long execID, long callerID, long functionID, ZFrame replyAddr, long senderTimestampNano, Object[] arguments) throws InterruptedException {
+    private void executeFunction(String name, String service, long execID, long callerID, long functionID,
+                                 ZFrame replyAddr, long senderTimestampNano, Object[] arguments) throws InterruptedException {
         FunctionOutput o = null;
         long tStart = System.nanoTime();
         try {
@@ -227,23 +206,7 @@ public class ApiaryWorker {
         Object output = currTask.getFinalOutput();
         // If the output is not null, meaning everything is done. Directly return.
         if (output != null) {
-            ExecuteFunctionReply.Builder b = ExecuteFunctionReply.newBuilder()
-                    .setCallerId(callerID)
-                    .setFunctionId(functionID)
-                    .setSenderTimestampNano(senderTimestampNano);
-            if (output instanceof String) {
-                b.setReplyType(stringType);
-                b.setReplyString((String) output);
-            } else if (output instanceof Integer) {
-                b.setReplyType(intType);
-                b.setReplyInt((int) output);
-            } else if (output instanceof String[]) {
-                b.setReplyType(stringArrayType);
-                b.setReplyArray(ByteString.copyFrom(Utilities.stringArraytoByteArray((String[]) output)));
-            } else if (output instanceof int[]) {
-                b.setReplyType(intArrayType);
-                b.setReplyArray(ByteString.copyFrom(Utilities.intArrayToByteArray((int[]) output)));
-            }
+            ExecuteFunctionReply.Builder b = Utilities.constructReply(callerID, functionID, senderTimestampNano, output);
             outgoingReplyMsgQueue.add(new OutgoingMsg(replyAddr, b.build().toByteArray()));
         }
         // Record runtime.
@@ -319,16 +282,7 @@ public class ApiaryWorker {
             // Handle the reply.
             try {
                 ExecuteFunctionReply reply = ExecuteFunctionReply.parseFrom(replyBytes);
-                Object output = null;
-                if (reply.getReplyType() == ApiaryWorker.stringType) {
-                    output = reply.getReplyString();
-                } else if (reply.getReplyType() == ApiaryWorker.intType) {
-                    output = reply.getReplyInt();
-                } else if (reply.getReplyType() == ApiaryWorker.stringArrayType) {
-                    output = Utilities.byteArrayToStringArray(reply.getReplyArray().toByteArray());
-                } else if (reply.getReplyType() == ApiaryWorker.intArrayType) {
-                    output = Utilities.byteArrayToIntArray(reply.getReplyArray().toByteArray());
-                }
+                Object output = Utilities.getOutputFromReply(reply);
                 long callerID = reply.getCallerId();
                 long functionID = reply.getFunctionId();
                 // Resume execution.

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -50,7 +50,8 @@ public class ApiaryWorker {
     public final WorkerContext workerContext;
 
     public ApiaryWorker(ApiaryScheduler scheduler, int numWorkerThreads) {
-        this(scheduler, numWorkerThreads, ApiaryConfig.vertica, ApiaryConfig.provenanceDefaultAddress);
+        // By default, no provenance buffer.
+        this(scheduler, numWorkerThreads, null, null);
     }
 
     public ApiaryWorker(ApiaryScheduler scheduler, int numWorkerThreads, String provenanceDatabase, String provenanceAddress) {

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorkerExecutable.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorkerExecutable.java
@@ -58,12 +58,15 @@ public class ApiaryWorkerExecutable {
             numThreads = Integer.parseInt(cmd.getOptionValue("t"));
         }
         logger.info("{} worker threads", numThreads);
-        ApiaryWorker worker = new ApiaryWorker(scheduler, numThreads);
+        ApiaryWorker worker;
 
         // Register all stateless functions for experiments.
         if (db.equals("voltdb")) {
+            worker = new ApiaryWorker(scheduler, numThreads, ApiaryConfig.vertica, ApiaryConfig.provenanceDefaultAddress);
             worker.registerFunction("RetwisMerge", ApiaryConfig.stateless, RetwisMerge::new);
             worker.registerFunction("IncrementStatelessDriver", ApiaryConfig.stateless, IncrementStatelessDriver::new);
+        } else {
+            worker = new ApiaryWorker(scheduler, numThreads, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
         }
 
         worker.startServing();

--- a/src/test/java/org/dbos/apiary/CrossDBTests.java
+++ b/src/test/java/org/dbos/apiary/CrossDBTests.java
@@ -34,7 +34,6 @@ public class CrossDBTests {
             conn.dropTable("PersonTable");
             conn.createTable("PersonTable", "Name varchar(1000) NOT NULL, Number integer PRIMARY KEY NOT NULL");
         } catch (Exception e) {
-            e.printStackTrace();
             logger.info("Failed to connect to Postgres.");
         }
         apiaryWorker = null;

--- a/src/test/java/org/dbos/apiary/PostgresTests.java
+++ b/src/test/java/org/dbos/apiary/PostgresTests.java
@@ -70,7 +70,7 @@ public class PostgresTests {
             return;
         }
 
-        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4);
+        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
         apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);
         apiaryWorker.registerFunction("PostgresFibonacciFunction", ApiaryConfig.postgres, PostgresFibonacciFunction::new);
         apiaryWorker.registerFunction("PostgresFibSumFunction", ApiaryConfig.postgres, PostgresFibSumFunction::new);
@@ -171,7 +171,7 @@ public class PostgresTests {
             return;
         }
 
-        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4);
+        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
         apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);
         apiaryWorker.registerFunction("RetwisPost", ApiaryConfig.postgres, RetwisPost::new);
         apiaryWorker.registerFunction("RetwisFollow", ApiaryConfig.postgres, RetwisFollow::new);
@@ -219,7 +219,7 @@ public class PostgresTests {
             return;
         }
 
-        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 1, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
+        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
         apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);
         apiaryWorker.registerFunction("PostgresProvenanceBasic", ApiaryConfig.postgres, PostgresProvenanceBasic::new);
         apiaryWorker.startServing();
@@ -351,7 +351,7 @@ public class PostgresTests {
             return;
         }
 
-        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 1, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
+        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
         apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);
         apiaryWorker.registerFunction("PostgresProvenanceJoins", ApiaryConfig.postgres, PostgresProvenanceJoins::new);
         apiaryWorker.startServing();

--- a/src/test/java/org/dbos/apiary/VoltDBTests.java
+++ b/src/test/java/org/dbos/apiary/VoltDBTests.java
@@ -49,7 +49,7 @@ public class VoltDBTests {
     public void testVoltProvenance() throws IOException, SQLException, InterruptedException {
         logger.info("testVoltProvenance");
         ApiaryConnection c = new VoltConnection("localhost", ApiaryConfig.voltdbPort);
-        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4);
+        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.vertica, ApiaryConfig.provenanceDefaultAddress);
         apiaryWorker.registerConnection(ApiaryConfig.voltdb, c);
         apiaryWorker.registerFunction("VoltProvenanceBasic", ApiaryConfig.voltdb, VoltProvenanceBasic::new);
         apiaryWorker.startServing();

--- a/src/test/java/org/dbos/apiary/WorkerTests.java
+++ b/src/test/java/org/dbos/apiary/WorkerTests.java
@@ -171,9 +171,6 @@ public class WorkerTests {
         res = client.executeFunction("CounterFunction", "1").getString();
         assertEquals("1", res);
 
-        // Should be able to see provenance data if Vertica is running.
-        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
-
         worker.shutdown();
     }
 


### PR DESCRIPTION
Fixed a minor bug in worker -- return finalOutput instead of output.

If no provenance database was provided, then the worker would have no provenance buffer (previously assume the default database was Vertica which was wrong).