### PR TITLE
MySQL secondary MVCC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,11 @@
             <version>42.3.3</version>
         </dependency>
         <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.29</version>
+        </dependency>
+        <dependency>
             <groupId>com.vertica.jdbc</groupId>
             <artifactId>vertica-jdbc</artifactId>
             <version>10.1.1-0</version>

--- a/scripts/init_mysql.sql
+++ b/scripts/init_mysql.sql
@@ -1,0 +1,4 @@
+-- MySQL database name and table name are case sensitive in Unix/Linux!
+-- But column names are not.
+CREATE DATABASE IF NOT EXISTS dbos;
+USE dbos;

--- a/scripts/initialize_mysql_docker.sh
+++ b/scripts/initialize_mysql_docker.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -ex
+
+SCRIPT_DIR=$(dirname $(realpath $0))
+cd ${SCRIPT_DIR}
+
+# Start Postgres Docker image.
+docker pull mysql
+
+# Set the password to dbos, default user is .
+docker run -d --network host --rm --name="apiary-mysql" --env MYSQL_ROOT_PASSWORD=dbos mysql:latest
+
+# Create DBOS database.
+docker exec -i apiary-mysql mysql -hlocalhost -uroot -pdbos -t < init_mysql.sql

--- a/scripts/initialize_mysql_docker.sh
+++ b/scripts/initialize_mysql_docker.sh
@@ -10,5 +10,8 @@ docker pull mysql
 # Set the password to dbos, default user is .
 docker run -d --network host --rm --name="apiary-mysql" --env MYSQL_ROOT_PASSWORD=dbos mysql:latest
 
+# Wait a bit.
+sleep 10
+
 # Create DBOS database.
 docker exec -i apiary-mysql mysql -hlocalhost -uroot -pdbos -t < init_mysql.sql

--- a/src/main/java/org/dbos/apiary/mysql/MysqlConnection.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlConnection.java
@@ -153,7 +153,6 @@ public class MysqlConnection implements ApiarySecondaryConnection {
                     if (!keyString.isEmpty()) {
                         query = String.format("UPDATE %s SET %s = %d WHERE %s IN (%s) AND %s < %d AND %s = %d", table, MysqlContext.endVersion, txc.txID, MysqlContext.apiaryID, keyString, MysqlContext.beginVersion, txc.txID, MysqlContext.endVersion, Long.MAX_VALUE);
                         s.execute(query);
-                        logger.info(query);
                     }
                 }
                 s.close();

--- a/src/main/java/org/dbos/apiary/mysql/MysqlConnection.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlConnection.java
@@ -64,6 +64,7 @@ public class MysqlConnection implements ApiarySecondaryConnection {
     }
 
     public void createTable(String tableName, String specStr) throws SQLException {
+        // TODO: How do we interact with the original primary key columns to avoid conflicts? Add Apiary columns as part of primary key? For now, assume no primary key columns.
         // Automatically add three additional columns: apiaryID, beginVersion, endVersion.
         Connection conn = ds.getConnection();
         Statement s = conn.createStatement();

--- a/src/main/java/org/dbos/apiary/mysql/MysqlConnection.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlConnection.java
@@ -71,7 +71,7 @@ public class MysqlConnection implements ApiarySecondaryConnection {
         String apiaryTable = String.format(
                 "CREATE TABLE IF NOT EXISTS %s (%s VARCHAR(256) NOT NULL, %s BIGINT, %s BIGINT, %s);"
         , tableName, MysqlContext.apiaryID, MysqlContext.beginVersion, MysqlContext.endVersion, specStr);
-        logger.info("Create table: {}", apiaryTable);
+        logger.debug("Create table: {}", apiaryTable);
         s.execute(apiaryTable);
         s.close();
         conn.close();
@@ -151,7 +151,7 @@ public class MysqlConnection implements ApiarySecondaryConnection {
                 for (String table : writtenKeys.keySet()) {
                     for (String key : writtenKeys.get(table)) {
                         query = String.format("UPDATE %s SET %s = %d WHERE %s = '%s' AND %s < %d AND %s = %d", table, MysqlContext.endVersion, txc.txID, MysqlContext.apiaryID, key, MysqlContext.beginVersion, txc.txID, MysqlContext.endVersion, Long.MAX_VALUE);
-                        logger.info("Validate update query: {}", query);
+                        logger.debug("Validate update query: {}", query);
                         s.execute(query);
                     }
                 }

--- a/src/main/java/org/dbos/apiary/mysql/MysqlConnection.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlConnection.java
@@ -71,7 +71,6 @@ public class MysqlConnection implements ApiarySecondaryConnection {
         String apiaryTable = String.format(
                 "CREATE TABLE IF NOT EXISTS %s (%s VARCHAR(256) NOT NULL, %s BIGINT, %s BIGINT, %s);"
         , tableName, MysqlContext.apiaryID, MysqlContext.beginVersion, MysqlContext.endVersion, specStr);
-        logger.debug("Create table: {}", apiaryTable);
         s.execute(apiaryTable);
         s.close();
         conn.close();
@@ -151,8 +150,6 @@ public class MysqlConnection implements ApiarySecondaryConnection {
                 for (String table : writtenKeys.keySet()) {
                     for (String key : writtenKeys.get(table)) {
                         query = String.format("UPDATE %s SET %s = %d WHERE %s = '%s' AND %s < %d AND %s = %d", table, MysqlContext.endVersion, txc.txID, MysqlContext.apiaryID, key, MysqlContext.beginVersion, txc.txID, MysqlContext.endVersion, Long.MAX_VALUE);
-                        logger.debug("Validate update query: {}", query);
-                        s.execute(query);
                     }
                 }
                 s.close();

--- a/src/main/java/org/dbos/apiary/mysql/MysqlConnection.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlConnection.java
@@ -1,0 +1,186 @@
+package org.dbos.apiary.mysql;
+
+import com.mysql.cj.jdbc.MysqlDataSource;
+import org.dbos.apiary.connection.ApiarySecondaryConnection;
+import org.dbos.apiary.function.FunctionOutput;
+import org.dbos.apiary.function.TransactionContext;
+import org.dbos.apiary.function.WorkerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class MysqlConnection implements ApiarySecondaryConnection {
+    private static final Logger logger = LoggerFactory.getLogger(MysqlConnection.class);
+
+    private final MysqlDataSource ds;
+    private final ThreadLocal<Connection> connection;
+
+    private final Map<String, Map<String, Set<Long>>> committedWrites = new ConcurrentHashMap<>();
+    private final Lock validationLock = new ReentrantLock();
+
+    public MysqlConnection(String hostname, Integer port, String databaseName, String databaseUsername, String databasePassword) throws SQLException {
+        this.ds = new MysqlDataSource();
+        // Set dataSource Properties
+        this.ds.setServerName(hostname);
+        this.ds.setPortNumber(port);
+        this.ds.setDatabaseName(databaseName);
+        this.ds.setUser(databaseUsername);
+        this.ds.setPassword(databasePassword);
+
+        this.connection = ThreadLocal.withInitial(() -> {
+            try {
+                Connection conn = ds.getConnection();
+                conn.setAutoCommit(true);
+                // conn.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
+                return conn;
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+            return null;
+        });
+
+        try {
+            Connection testConn = ds.getConnection();
+            testConn.close();
+        } catch (SQLException e) {
+            logger.info("Failed to connect to MySQL");
+            throw new RuntimeException("Failed to connect to MySQL");
+        }
+    }
+
+    public void dropTable(String tableName) throws SQLException {
+        Connection conn = ds.getConnection();
+        Statement truncateTable = conn.createStatement();
+        truncateTable.execute(String.format("DROP TABLE IF EXISTS %s;", tableName));
+        truncateTable.close();
+        conn.close();
+    }
+
+    public void createTable(String tableName, String specStr) throws SQLException {
+        // Automatically add three additional columns: apiaryID, beginVersion, endVersion.
+        Connection conn = ds.getConnection();
+        Statement s = conn.createStatement();
+        String apiaryTable = String.format(
+                "CREATE TABLE IF NOT EXISTS %s (%s VARCHAR(256) NOT NULL, %s BIGINT, %s BIGINT, %s);"
+        , tableName, MysqlContext.apiaryID, MysqlContext.beginVersion, MysqlContext.endVersion, specStr);
+        logger.info("Create table: {}", apiaryTable);
+        s.execute(apiaryTable);
+        s.close();
+        conn.close();
+    }
+
+    public void createIndex(String indexString) throws SQLException {
+        Connection c = ds.getConnection();
+        Statement s = c.createStatement();
+        s.execute(indexString);
+        s.close();
+        c.close();
+    }
+
+    @Override
+    public FunctionOutput callFunction(String functionName, WorkerContext workerContext, TransactionContext txc, String service, long execID, long functionID, Object... inputs) throws Exception {
+        MysqlContext ctxt = new MysqlContext(this.connection.get(), workerContext, txc, service, execID, functionID);
+        FunctionOutput f = null;
+        try {
+            f = workerContext.getFunction(functionName).apiaryRunFunction(ctxt, inputs);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return f;
+    }
+
+    @Override
+    public void rollback(Map<String, List<String>> writtenKeys, TransactionContext txc) {
+        String query = "";
+        try {
+            Connection c = ds.getConnection();
+            Statement s = c.createStatement();
+            for (String table : writtenKeys.keySet()) {
+                query = String.format("DELETE FROM %s WHERE %s = %d", table, MysqlContext.beginVersion, txc.txID);
+                s.execute(query);
+            }
+            s.close();
+            c.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+            logger.error("Failed to rollback txn {}", txc.txID);
+            logger.info("Rollback query: {}", query);
+        }
+    }
+
+    @Override
+    public boolean validate(Map<String, List<String>> writtenKeys, TransactionContext txc) {
+        Set<Long> activeTransactions = new HashSet<>(txc.activeTransactions);
+        validationLock.lock();
+        boolean valid = true;
+        for (String table: writtenKeys.keySet()) {
+            for (String key : writtenKeys.get(table)) {
+                // Has the key been modified by a transaction not in the snapshot?
+                Set<Long> writes = committedWrites.getOrDefault(table, Collections.emptyMap()).getOrDefault(key, Collections.emptySet());
+                for (Long write : writes) {
+                    if (write >= txc.xmax || activeTransactions.contains(write)) {
+                        valid = false;
+                        break;
+                    }
+                }
+            }
+        }
+        if (valid) {
+            for (String collection: writtenKeys.keySet()) {
+                for (String key : writtenKeys.get(collection)) {
+                    committedWrites.putIfAbsent(collection, new ConcurrentHashMap<>());
+                    committedWrites.get(collection).putIfAbsent(key, ConcurrentHashMap.newKeySet());
+                    committedWrites.get(collection).get(key).add(txc.txID);
+                }
+            }
+        }
+        validationLock.unlock();
+        if (valid) {
+            String query = "";
+            try {
+                Connection c = ds.getConnection();
+                Statement s = c.createStatement();
+                for (String table : writtenKeys.keySet()) {
+                    for (String key : writtenKeys.get(table)) {
+                        query = String.format("UPDATE %s SET %s = %d WHERE %s = '%s' AND %s < %d AND %s = %d", table, MysqlContext.endVersion, txc.txID, MysqlContext.apiaryID, key, MysqlContext.beginVersion, txc.txID, MysqlContext.endVersion, Long.MAX_VALUE);
+                        s.execute(query);
+                    }
+                }
+                s.close();
+                c.close();
+            } catch (Exception e) {
+                e.printStackTrace();
+                logger.error("Failed to update valid txn {}", txc.txID);
+                logger.info("Validate update query: {}", query);
+            }
+        }
+        return valid;
+    }
+
+    @Override
+    public void garbageCollect(Set<TransactionContext> activeTransactions) {
+        long globalxmin = activeTransactions.stream().mapToLong(i -> i.xmin).min().getAsLong();
+        // No need to keep track of writes that are visible to all active or future transactions.
+        committedWrites.values().forEach(i -> i.values().forEach(w -> w.removeIf(txID -> txID < globalxmin)));
+        // Delete old versions that are no longer visible to any active or future transaction.
+        String query = "";
+        try {
+            Connection c = ds.getConnection();
+            Statement s = c.createStatement();
+            for (String tableName : committedWrites.keySet()) {
+                query = String.format("DELETE FROM %s WHERE %s < %d", tableName, MysqlContext.endVersion, globalxmin);
+                s.execute(query);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            logger.error("Failed to garbage collect: {}", query);
+        }
+    }
+}

--- a/src/main/java/org/dbos/apiary/mysql/MysqlConnection.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlConnection.java
@@ -150,6 +150,7 @@ public class MysqlConnection implements ApiarySecondaryConnection {
                 for (String table : writtenKeys.keySet()) {
                     for (String key : writtenKeys.get(table)) {
                         query = String.format("UPDATE %s SET %s = %d WHERE %s = '%s' AND %s < %d AND %s = %d", table, MysqlContext.endVersion, txc.txID, MysqlContext.apiaryID, key, MysqlContext.beginVersion, txc.txID, MysqlContext.endVersion, Long.MAX_VALUE);
+                        s.execute(query);
                     }
                 }
                 s.close();

--- a/src/main/java/org/dbos/apiary/mysql/MysqlConnection.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlConnection.java
@@ -151,6 +151,7 @@ public class MysqlConnection implements ApiarySecondaryConnection {
                 for (String table : writtenKeys.keySet()) {
                     for (String key : writtenKeys.get(table)) {
                         query = String.format("UPDATE %s SET %s = %d WHERE %s = '%s' AND %s < %d AND %s = %d", table, MysqlContext.endVersion, txc.txID, MysqlContext.apiaryID, key, MysqlContext.beginVersion, txc.txID, MysqlContext.endVersion, Long.MAX_VALUE);
+                        logger.info("Validate update query: {}", query);
                         s.execute(query);
                     }
                 }

--- a/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
@@ -41,6 +41,8 @@ public class MysqlContext extends ApiaryContext {
                 ps.setInt(i + 1, (Integer) o);
             } else if (o instanceof String) {
                 ps.setString(i + 1, (String) o);
+            } else if (o instanceof Long)  {
+                ps.setLong(i + 1, (Long) o);
             } else {
                 assert (false); // TODO: More types.
             }

--- a/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
@@ -11,6 +11,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,6 +58,8 @@ public class MysqlContext extends ApiaryContext {
         }
         query.append(");");
         logger.info(query.toString());
+        writtenKeys.putIfAbsent(tableName, new ArrayList<>());
+        writtenKeys.get(tableName).add(id);
         PreparedStatement pstmt = conn.prepareStatement(query.toString());
         Object[] apiaryInput = new Object[input.length + 3];
         apiaryInput[0] = id;

--- a/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
@@ -57,7 +57,7 @@ public class MysqlContext extends ApiaryContext {
             query.append(", ?");
         }
         query.append(");");
-        logger.info(query.toString());
+        logger.debug(query.toString());
         writtenKeys.putIfAbsent(tableName, new ArrayList<>());
         writtenKeys.get(tableName).add(id);
         PreparedStatement pstmt = conn.prepareStatement(query.toString());
@@ -87,7 +87,7 @@ public class MysqlContext extends ApiaryContext {
         }
 
         filterQuery.append("); ");
-        logger.info(filterQuery.toString());
+        logger.debug(filterQuery.toString());
 
         PreparedStatement pstmt = conn.prepareStatement(filterQuery.toString());
         prepareStatement(pstmt, input);

--- a/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
@@ -57,7 +57,6 @@ public class MysqlContext extends ApiaryContext {
             query.append(", ?");
         }
         query.append(");");
-        logger.debug(query.toString());
         writtenKeys.putIfAbsent(tableName, new ArrayList<>());
         writtenKeys.get(tableName).add(id);
         PreparedStatement pstmt = conn.prepareStatement(query.toString());
@@ -87,7 +86,6 @@ public class MysqlContext extends ApiaryContext {
         }
 
         filterQuery.append("); ");
-        logger.debug(filterQuery.toString());
 
         PreparedStatement pstmt = conn.prepareStatement(filterQuery.toString());
         prepareStatement(pstmt, input);

--- a/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
@@ -1,0 +1,95 @@
+package org.dbos.apiary.mysql;
+
+import org.dbos.apiary.function.ApiaryContext;
+import org.dbos.apiary.function.FunctionOutput;
+import org.dbos.apiary.function.TransactionContext;
+import org.dbos.apiary.function.WorkerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class MysqlContext extends ApiaryContext {
+    private static final Logger logger = LoggerFactory.getLogger(MysqlContext.class);
+    public static final String apiaryID = "__apiaryID__";
+    public static final String beginVersion = "__beginVersion__";
+    public static final String endVersion = "__endVersion__";
+
+    private final Connection conn;
+
+    private final TransactionContext txc;
+
+    Map<String, List<String>> writtenKeys = new HashMap<>();
+
+    public MysqlContext(Connection conn, WorkerContext workerContext, TransactionContext txc, String service, long execID, long functionID) {
+        super(workerContext, service, execID, functionID);
+        this.conn = conn;
+        this.txc = txc;
+    }
+
+    private void prepareStatement(PreparedStatement ps, Object[] input) throws SQLException {
+        for (int i = 0; i < input.length; i++) {
+            Object o = input[i];
+            if (o instanceof Integer) {
+                ps.setInt(i + 1, (Integer) o);
+            } else if (o instanceof String) {
+                ps.setString(i + 1, (String) o);
+            } else {
+                assert (false); // TODO: More types.
+            }
+        }
+    }
+
+    public void executeUpsert(String tableName, String id, Object... input) throws SQLException {
+        // TODO: This interface is not the natural SQL interface. Figure out a better one? E.g., can we support arbitrary update queries?
+        StringBuilder query = new StringBuilder(String.format("INSERT INTO %s VALUES (?, ?, ?"));
+        for (int i = 0; i < input.length; i++) {
+            query.append(", ?");
+        }
+        query.append(");");
+        logger.info(query.toString());
+        PreparedStatement pstmt = conn.prepareStatement(query.toString());
+        Object[] apiaryInput = new Object[input.length + 3];
+        apiaryInput[0] = id;
+        apiaryInput[1] = txc.txID;
+        apiaryInput[2] = Long.MAX_VALUE;
+        System.arraycopy(input, 0, apiaryInput, 3, input.length);
+        prepareStatement(pstmt, apiaryInput);
+        pstmt.executeUpdate();
+    }
+
+    public ResultSet executeQuery(String procedure, Object... input) throws SQLException {
+        // TODO: This implementation assume predicates at the end. No more group by or others. May find a better solution.
+        // Also hard to use prepared statement because the number of active transactions varies.
+        String sanitizeQuery = procedure.replaceAll(";+$", "");
+        StringBuilder filterQuery = new StringBuilder(sanitizeQuery);
+        String activeTxnString = txc.activeTransactions.stream().map(Object::toString).collect(Collectors.joining(","));
+        // Add filters to the end.
+        filterQuery.append(String.format(" AND %s < %d ", beginVersion, txc.xmax));
+        filterQuery.append(String.format(" AND %s NOT IN (%s) ", beginVersion, activeTxnString));
+        filterQuery.append(String.format(" AND ( %s >= %d ", endVersion, txc.xmax));
+        filterQuery.append(String.format(" OR %s IN (%s) ", endVersion, activeTxnString));
+
+        filterQuery.append("); ");
+        logger.info(filterQuery.toString());
+
+        PreparedStatement pstmt = conn.prepareStatement(filterQuery.toString());
+        prepareStatement(pstmt, input);
+        ResultSet rs = pstmt.executeQuery();
+
+        return rs;
+    }
+
+    @Override
+    public FunctionOutput apiaryCallFunction(String name, Object... inputs) throws Exception {
+        // TODO: implement.
+        return null;
+    }
+}

--- a/src/main/java/org/dbos/apiary/mysql/MysqlFunction.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlFunction.java
@@ -1,0 +1,22 @@
+package org.dbos.apiary.mysql;
+
+import org.dbos.apiary.function.ApiaryContext;
+import org.dbos.apiary.function.ApiaryFunction;
+import org.dbos.apiary.function.FunctionOutput;
+
+public class MysqlFunction implements ApiaryFunction {
+
+    @Override
+    public FunctionOutput apiaryRunFunction(ApiaryContext apiaryContext, Object... input) throws Exception {
+        MysqlContext ctxt = (MysqlContext) apiaryContext;
+        FunctionOutput fo = ApiaryFunction.super.apiaryRunFunction(apiaryContext, input);
+        fo.setWrittenKeys(ctxt.writtenKeys);
+        return fo;
+    }
+
+    @Override
+    public void recordInvocation(ApiaryContext ctxt, String funcName) {
+
+    }
+
+}

--- a/src/main/java/org/dbos/apiary/procedures/mysql/MysqlQueryPerson.java
+++ b/src/main/java/org/dbos/apiary/procedures/mysql/MysqlQueryPerson.java
@@ -4,7 +4,6 @@ import org.dbos.apiary.mysql.MysqlContext;
 import org.dbos.apiary.mysql.MysqlFunction;
 
 import java.sql.ResultSet;
-import java.sql.SQLException;
 
 public class MysqlQueryPerson extends MysqlFunction {
     private final static String find = "SELECT COUNT(*) FROM PersonTable WHERE Name=? ;";

--- a/src/main/java/org/dbos/apiary/procedures/mysql/MysqlQueryPerson.java
+++ b/src/main/java/org/dbos/apiary/procedures/mysql/MysqlQueryPerson.java
@@ -9,7 +9,7 @@ import java.sql.SQLException;
 public class MysqlQueryPerson extends MysqlFunction {
     private final static String find = "SELECT COUNT(*) FROM PersonTable WHERE Name=? ;";
 
-    public static int runFunction(MysqlContext context, String name) throws SQLException {
+    public static int runFunction(MysqlContext context, String name) throws Exception {
         ResultSet rs = context.executeQuery(find, name);
         int count = 0;
         if (rs.next()) {

--- a/src/main/java/org/dbos/apiary/procedures/mysql/MysqlQueryPerson.java
+++ b/src/main/java/org/dbos/apiary/procedures/mysql/MysqlQueryPerson.java
@@ -1,0 +1,20 @@
+package org.dbos.apiary.procedures.mysql;
+
+import org.dbos.apiary.mysql.MysqlContext;
+import org.dbos.apiary.mysql.MysqlFunction;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class MysqlQueryPerson extends MysqlFunction {
+    private final static String find = "SELECT COUNT(*) FROM PersonTable WHERE Name=? ;";
+
+    public static int runFunction(MysqlContext context, String name) throws SQLException {
+        ResultSet rs = context.executeQuery(find, name);
+        int count = 0;
+        if (rs.next()) {
+            count = rs.getInt(1);
+        }
+        return count;
+    }
+}

--- a/src/main/java/org/dbos/apiary/procedures/mysql/MysqlUpsertPerson.java
+++ b/src/main/java/org/dbos/apiary/procedures/mysql/MysqlUpsertPerson.java
@@ -3,8 +3,6 @@ package org.dbos.apiary.procedures.mysql;
 import org.dbos.apiary.mysql.MysqlContext;
 import org.dbos.apiary.mysql.MysqlFunction;
 
-import java.sql.SQLException;
-
 public class MysqlUpsertPerson extends MysqlFunction {
 
     public static int runFunction(MysqlContext context, String name, int number) throws Exception {

--- a/src/main/java/org/dbos/apiary/procedures/mysql/MysqlUpsertPerson.java
+++ b/src/main/java/org/dbos/apiary/procedures/mysql/MysqlUpsertPerson.java
@@ -7,7 +7,7 @@ import java.sql.SQLException;
 
 public class MysqlUpsertPerson extends MysqlFunction {
 
-    public static int runFunction(MysqlContext context, String name, int number) throws SQLException {
+    public static int runFunction(MysqlContext context, String name, int number) throws Exception {
         context.executeUpsert("PersonTable", name, name, number);
         return number;
     }

--- a/src/main/java/org/dbos/apiary/procedures/mysql/MysqlUpsertPerson.java
+++ b/src/main/java/org/dbos/apiary/procedures/mysql/MysqlUpsertPerson.java
@@ -1,0 +1,14 @@
+package org.dbos.apiary.procedures.mysql;
+
+import org.dbos.apiary.mysql.MysqlContext;
+import org.dbos.apiary.mysql.MysqlFunction;
+
+import java.sql.SQLException;
+
+public class MysqlUpsertPerson extends MysqlFunction {
+
+    public static int runFunction(MysqlContext context, String name, int number) throws SQLException {
+        context.executeUpsert("PersonTable", name, name, number);
+        return number;
+    }
+}

--- a/src/main/java/org/dbos/apiary/procedures/postgres/pgmysql/PostgresQueryPerson.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/pgmysql/PostgresQueryPerson.java
@@ -1,0 +1,30 @@
+package org.dbos.apiary.procedures.postgres.pgmysql;
+
+import org.dbos.apiary.postgres.PostgresContext;
+import org.dbos.apiary.postgres.PostgresFunction;
+import org.dbos.apiary.procedures.postgres.pgmongo.PostgresFindPerson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.ResultSet;
+
+public class PostgresQueryPerson extends PostgresFunction {
+
+    private static final Logger logger = LoggerFactory.getLogger(PostgresFindPerson.class);
+
+    private final static String find = "SELECT COUNT(*) FROM PersonTable WHERE Name=?";
+
+    public static int runFunction(PostgresContext ctxt, String search) throws Exception {
+        ResultSet rs = ctxt.executeQuery(find, search);
+        rs.next();
+        int pgCount = rs.getInt(1);
+        int mysqlCount = ctxt.apiaryCallFunction("MysqlQueryPerson", search).getInt();
+        if (pgCount == mysqlCount) {
+            return pgCount;
+        } else {
+            logger.info("Inconsistency: {} postgres: {} mysql: {} txID: {} xmin: {} xmax: {} activeTxns: {}", search, pgCount, mysqlCount,
+                    ctxt.txc.txID, ctxt.txc.xmin, ctxt.txc.xmax, ctxt.txc.activeTransactions);
+            return -1;
+        }
+    }
+}

--- a/src/main/java/org/dbos/apiary/procedures/postgres/pgmysql/PostgresUpsertPerson.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/pgmysql/PostgresUpsertPerson.java
@@ -1,0 +1,15 @@
+package org.dbos.apiary.procedures.postgres.pgmysql;
+
+import org.dbos.apiary.postgres.PostgresContext;
+import org.dbos.apiary.postgres.PostgresFunction;
+
+public class PostgresUpsertPerson extends PostgresFunction {
+
+    private static final String insert = "INSERT INTO PersonTable(Name, Number) VALUES (?, ?) ON CONFLICT (Name) DO UPDATE SET Number = EXCLUDED.Number;";
+
+    public static int runFunction(PostgresContext ctxt, String name, int number) throws Exception {
+        ctxt.apiaryCallFunction("MysqlUpsertPerson", name, number);
+        ctxt.executeUpdate(insert, name, number);
+        return number;
+    }
+}

--- a/src/main/java/org/dbos/apiary/utilities/ApiaryConfig.java
+++ b/src/main/java/org/dbos/apiary/utilities/ApiaryConfig.java
@@ -4,6 +4,7 @@ public class ApiaryConfig {
     public static final int voltdbPort = 21212;
     public static final int workerPort = 8000;
     public static final int postgresPort = 5432;
+    public static final int mysqlPort = 3306;
     public static final long statelessTxid = 1L;
     public static final String tableFuncInvocations = "FUNCINVOCATIONS";
 
@@ -28,4 +29,5 @@ public class ApiaryConfig {
 
     // GCS bucket names.
     public static final String gcsTestBucket = "apiary_gcs_test";
+    public static final String mysql = "mysql";
 }

--- a/src/test/java/org/dbos/apiary/PostgresMysqlTests.java
+++ b/src/test/java/org/dbos/apiary/PostgresMysqlTests.java
@@ -1,0 +1,91 @@
+package org.dbos.apiary;
+
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.dbos.apiary.client.ApiaryWorkerClient;
+import org.dbos.apiary.mysql.MysqlConnection;
+import org.dbos.apiary.postgres.PostgresConnection;
+import org.dbos.apiary.procedures.mysql.MysqlQueryPerson;
+import org.dbos.apiary.procedures.mysql.MysqlUpsertPerson;
+import org.dbos.apiary.procedures.postgres.pgmysql.PostgresQueryPerson;
+import org.dbos.apiary.procedures.postgres.pgmysql.PostgresUpsertPerson;
+import org.dbos.apiary.utilities.ApiaryConfig;
+import org.dbos.apiary.worker.ApiaryNaiveScheduler;
+import org.dbos.apiary.worker.ApiaryWorker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PostgresMysqlTests {
+    private static final Logger logger = LoggerFactory.getLogger(PostgresMysqlTests.class);
+
+    private ApiaryWorker apiaryWorker;
+    @BeforeEach
+    public void resetTables() {
+        try {
+            PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, ApiaryConfig.postgres, ApiaryConfig.postgres, "dbos");
+            conn.dropTable("FuncInvocations");
+            conn.dropTable("PersonTable");
+            conn.createTable("PersonTable", "Name varchar(1000) PRIMARY KEY NOT NULL, Number integer NOT NULL");
+        } catch (Exception e) {
+            logger.info("Failed to connect to Postgres.");
+        }
+
+        try {
+            MysqlConnection conn = new MysqlConnection("localhost", ApiaryConfig.mysqlPort, "dbos", "root", "dbos");
+            conn.dropTable("PersonTable");
+            // TODO: need to solve the primary key issue. Currently cannot have primary keys.
+            conn.createTable("PersonTable", "Name varchar(1000) NOT NULL, Number integer NOT NULL");
+        } catch (Exception e) {
+            logger.info("Failed to connect to MySQL.");
+        }
+
+        apiaryWorker = null;
+    }
+
+    @AfterEach
+    public void cleanupWorker() {
+        if (apiaryWorker != null) {
+            apiaryWorker.shutdown();
+        }
+    }
+
+    @Test
+    public void testMysqlBasic() throws InvalidProtocolBufferException {
+        logger.info("testMysqlBasic");
+
+        MysqlConnection conn;
+        PostgresConnection pconn;
+        try {
+            conn = new MysqlConnection("localhost", ApiaryConfig.mysqlPort, "dbos", "root", "dbos");
+            pconn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, ApiaryConfig.postgres, ApiaryConfig.postgres, "dbos");
+        } catch (Exception e) {
+            logger.info("No MySQL/Postgres instance! {}", e.getMessage());
+            return;
+        }
+
+        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4);
+        apiaryWorker.registerConnection(ApiaryConfig.mysql, conn);
+        apiaryWorker.registerConnection(ApiaryConfig.postgres, pconn);
+        apiaryWorker.registerFunction("PostgresUpsertPerson", ApiaryConfig.postgres, PostgresUpsertPerson::new);
+        apiaryWorker.registerFunction("PostgresQueryPerson", ApiaryConfig.postgres, PostgresQueryPerson::new);
+        apiaryWorker.registerFunction("MysqlUpsertPerson", ApiaryConfig.mysql, MysqlUpsertPerson::new);
+        apiaryWorker.registerFunction("MysqlQueryPerson", ApiaryConfig.mysql, MysqlQueryPerson::new);
+
+        apiaryWorker.startServing();
+
+        ApiaryWorkerClient client = new ApiaryWorkerClient("localhost");
+
+        int res;
+        res = client.executeFunction("PostgresUpsertPerson", "matei", 1).getInt();
+        assertEquals(1, res);
+
+        res = client.executeFunction("PostgresQueryPerson", "matei").getInt();
+        assertEquals(1, res);
+    }
+
+}

--- a/src/test/java/org/dbos/apiary/PostgresMysqlTests.java
+++ b/src/test/java/org/dbos/apiary/PostgresMysqlTests.java
@@ -171,7 +171,7 @@ public class PostgresMysqlTests {
                     int localCount = count.getAndIncrement();
                     client.executeFunction("PostgresUpsertPerson", "matei" + localCount, localCount).getInt();
                     String search = "matei" + ThreadLocalRandom.current().nextInt(localCount - 5, localCount + 5);
-                    int res = client.executeFunction("MysqlQueryPerson", search).getInt();
+                    int res = client.executeFunction("PostgresQueryPerson", search).getInt();
                     if (res == -1) {
                         success.set(false);
                     }


### PR DESCRIPTION
This PR implements Apiary MVCC in MySQL. Include a script to automatically start a MySQL docker container and create a `dbos` database: [initialize_mysql_docker.sh](https://github.com/DBOS-project/apiary/pull/84/files#diff-4d5fbe069c7a443dcf5ff7b9f7714e65835164c0ea18e95ed755e51e0cb7f8bd). 

Some known catches:
1. We automatically add three additional columns: apiaryID, beginVersion, endVersion for each MySQL table. How do we interact with the original primary key columns to avoid conflicts? Add Apiary columns as part of the primary key? For now, assume no primary key columns.
2. The "executeUpsert" interface is not the natural SQL interface because we need to intercept and add our begin/end version info. Can we support arbitrary update queries?
3. The "executeQuery" interface implementation assumes predicates at the end. No more group by or other clauses. May find a better solution to parse the SQL query and intercept with our filters. Also, it is hard to use prepared statements because the number of active transactions varies. Then we might hit the maximum number of pstmts.