### PR TITLE
Provenance Capture

### DIFF
--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -216,7 +216,7 @@ public class ProvenanceBuffer {
             }
             // Pad the rest with zeros.
             for (int j = numVals; j < numColumns; j++) {
-                setColumn(pstmt, j+1, Types.VARCHAR, padding);
+                setColumn(pstmt, j+1, Types.NULL, padding);
             }
             pstmt.addBatch();
             rowCnt++;

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -31,6 +31,7 @@ public class ProvenanceBuffer {
     public static final String PROV_PROCEDURENAME = "PROCEDURENAME";
     public static final String PROV_APIARY_OPERATION_TYPE = "APIARY_OPERATION_TYPE";
     public static final String PROV_QUERY_STRING = "QUERY_STRING";
+    public static final String PROV_QUERY_SEQNUM = "QUERY_SEQNUM";
 
     /**
      * Enum class for provenance operations.

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -214,9 +214,13 @@ public class ProvenanceBuffer {
                 // Column index starts with 1.
                 setColumn(pstmt, j+1, tableBuffer.colTypeMap.get(j+1), listVals[j]);
             }
-            // Pad the rest with zeros.
+            // Pad the rest with zeros if it's Vertica, because it doesn't support NULL very well.
             for (int j = numVals; j < numColumns; j++) {
-                setColumn(pstmt, j+1, Types.NULL, padding);
+                if (databaseName.equals(ApiaryConfig.vertica)) {
+                    setColumn(pstmt, j + 1, Types.VARCHAR, padding);
+                } else {
+                    setColumn(pstmt, j + 1, Types.NULL, null);
+                }
             }
             pstmt.addBatch();
             rowCnt++;

--- a/src/main/java/org/dbos/apiary/function/TransactionContext.java
+++ b/src/main/java/org/dbos/apiary/function/TransactionContext.java
@@ -1,6 +1,7 @@
 package org.dbos.apiary.function;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class TransactionContext {
 
@@ -8,11 +9,13 @@ public class TransactionContext {
     public final long xmin;
     public final long xmax;
     public final List<Long> activeTransactions;
+    public final AtomicInteger querySeqNum;  // Query sequence number within a transaction, starting from 0.
 
     public TransactionContext(long txID, long xmin, long xmax, List<Long> activeTransactions) {
         this.txID = txID;
         this.xmin = xmin;
         this.xmax = xmax;
         this.activeTransactions = activeTransactions;
+        this.querySeqNum = new AtomicInteger(0);
     }
 }

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -118,10 +118,10 @@ public class PostgresConnection implements ApiaryConnection {
             ResultSet r = s.executeQuery(String.format("SELECT * FROM %s", tableName));
             ResultSetMetaData rsmd = r.getMetaData();
             StringBuilder provTable = new StringBuilder(String.format(
-                    "CREATE TABLE IF NOT EXISTS %sEvents (%s BIGINT NOT NULL, %s BIGINT NOT NULL, %s BIGINT NOT NULL, %s VARCHAR(2048) NOT NULL",
+                    "CREATE TABLE IF NOT EXISTS %sEvents (%s BIGINT NOT NULL, %s BIGINT NOT NULL, %s BIGINT NOT NULL, %s VARCHAR(2048) NOT NULL, %s BIGINT NOT NULL",
                     tableName, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID,
                     ProvenanceBuffer.PROV_APIARY_TIMESTAMP, ProvenanceBuffer.PROV_APIARY_OPERATION_TYPE,
-                    ProvenanceBuffer.PROV_QUERY_STRING));
+                    ProvenanceBuffer.PROV_QUERY_STRING, ProvenanceBuffer.PROV_QUERY_SEQNUM));
             for (int i = 0; i < rsmd.getColumnCount(); i++) {
                 provTable.append(",");
                 provTable.append(rsmd.getColumnLabel(i + 1));

--- a/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
@@ -107,6 +107,7 @@ public class PostgresContext extends ApiaryContext {
      * @param input     input parameters for the SQL statement.
      */
     public void executeUpdate(String procedure, Object... input) throws SQLException {
+        int querySeqNum = txc.querySeqNum.getAndIncrement();
         if (ApiaryConfig.captureUpdates && (this.workerContext.provBuff != null)) {
             // Append the "RETURNING *" clause to the SQL query, so we can capture data updates.
             String interceptedQuery = interceptUpdate((String) procedure);
@@ -125,22 +126,23 @@ public class PostgresContext extends ApiaryContext {
             // Record provenance data.
             if (!rs.next()) {
                 // Still record an empty entry for the query.
-                Object[] rowData = new Object[4];
-                rowData[0] = txc.txID;
+                Object[] rowData = new Object[5];
                 rowData[1] = timestamp;
                 rowData[2] = exportOperation;
                 rowData[3] = pstmt.toString();
+                rowData[4] = querySeqNum;
                 workerContext.provBuff.addEntry(tableName + "Events", rowData);
             } else {
                 // Record each returned entry.
                 do {
-                    Object[] rowData = new Object[numCol + 4];
+                    Object[] rowData = new Object[numCol + 5];
                     rowData[0] = txc.txID;
                     rowData[1] = timestamp;
                     rowData[2] = exportOperation;
                     rowData[3] = pstmt.toString();
+                    rowData[4] = querySeqNum;
                     for (int i = 1; i <= numCol; i++) {
-                        rowData[i + 3] = rs.getObject(i);
+                        rowData[i + 4] = rs.getObject(i);
                     }
                     workerContext.provBuff.addEntry(tableName + "Events", rowData);
                 } while (rs.next());
@@ -162,6 +164,7 @@ public class PostgresContext extends ApiaryContext {
         PreparedStatement pstmt = conn.prepareStatement(procedure, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
         prepareStatement(pstmt, input);
         ResultSet rs = pstmt.executeQuery();
+        int querySeqNum = txc.querySeqNum.getAndIncrement();
         if (ApiaryConfig.captureReads && workerContext.provBuff != null) {
             long timestamp = Utilities.getMicroTimestamp();
             int exportOperation = Utilities.getQueryType(procedure);
@@ -172,11 +175,12 @@ public class PostgresContext extends ApiaryContext {
                 for (int colNum = 1; colNum <= rs.getMetaData().getColumnCount(); colNum++) {
                     String tableName = rs.getMetaData().getTableName(colNum);
                     if (!tableToRowData.containsKey(tableName)) {
-                        Object[] rowData = new Object[4];
+                        Object[] rowData = new Object[5];
                         rowData[0] = txc.txID;
                         rowData[1] = timestamp;
                         rowData[2] = exportOperation;
                         rowData[3] = pstmt.toString();
+                        rowData[4] = querySeqNum;
                         tableToRowData.put(tableName, rowData);
                     }
                 }
@@ -190,18 +194,19 @@ public class PostgresContext extends ApiaryContext {
                         String tableName = rs.getMetaData().getTableName(colNum);
                         Map<String, Integer> schemaMap = getSchemaMap(tableName);
                         if (!tableToRowData.containsKey(tableName)) {
-                            Object[] rowData = new Object[4 + schemaMap.size()];
+                            Object[] rowData = new Object[5 + schemaMap.size()];
                             rowData[0] = txc.txID;
                             rowData[1] = timestamp;
                             rowData[2] = exportOperation;
                             rowData[3] = pstmt.toString();
+                            rowData[4] = querySeqNum;
                             tableToRowData.put(tableName, rowData);
                         }
                         Object[] rowData = tableToRowData.get(tableName);
                         String columnName = rs.getMetaData().getColumnName(colNum);
                         if (schemaMap.containsKey(columnName)) {
                             int index = schemaMap.get(rs.getMetaData().getColumnName(colNum));
-                            rowData[4 + index] = rs.getObject(colNum);
+                            rowData[5 + index] = rs.getObject(colNum);
                         }
                     }
                     for (String tableName : tableToRowData.keySet()) {

--- a/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
@@ -185,7 +185,7 @@ public class PostgresContext extends ApiaryContext {
                 }
                 tableToRowData.clear();
             } else {
-                while (rs.next()) {
+                do {
                     for (int colNum = 1; colNum <= rs.getMetaData().getColumnCount(); colNum++) {
                         String tableName = rs.getMetaData().getTableName(colNum);
                         Map<String, Integer> schemaMap = getSchemaMap(tableName);
@@ -208,7 +208,7 @@ public class PostgresContext extends ApiaryContext {
                         workerContext.provBuff.addEntry(tableName + "Events", tableToRowData.get(tableName));
                     }
                     tableToRowData.clear();
-                }
+                } while (rs.next());
             }
             rs.beforeFirst();
         }

--- a/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
@@ -123,16 +123,27 @@ public class PostgresContext extends ApiaryContext {
             long timestamp = Utilities.getMicroTimestamp();
             int numCol = rsmd.getColumnCount();
             // Record provenance data.
-            while (rs.next()) {
-                Object[] rowData = new Object[numCol+4];
+            if (!rs.next()) {
+                // Still record an empty entry for the query.
+                Object[] rowData = new Object[4];
                 rowData[0] = txc.txID;
                 rowData[1] = timestamp;
                 rowData[2] = exportOperation;
                 rowData[3] = pstmt.toString();
-                for (int i = 1; i <= numCol; i++) {
-                    rowData[i+3] = rs.getObject(i);
-                }
                 workerContext.provBuff.addEntry(tableName + "Events", rowData);
+            } else {
+                // Record each returned entry.
+                do {
+                    Object[] rowData = new Object[numCol + 4];
+                    rowData[0] = txc.txID;
+                    rowData[1] = timestamp;
+                    rowData[2] = exportOperation;
+                    rowData[3] = pstmt.toString();
+                    for (int i = 1; i <= numCol; i++) {
+                        rowData[i + 3] = rs.getObject(i);
+                    }
+                    workerContext.provBuff.addEntry(tableName + "Events", rowData);
+                } while (rs.next());
             }
         } else {
             // First, prepare statement. Then, execute.
@@ -153,31 +164,51 @@ public class PostgresContext extends ApiaryContext {
         ResultSet rs = pstmt.executeQuery();
         if (ApiaryConfig.captureReads && workerContext.provBuff != null) {
             long timestamp = Utilities.getMicroTimestamp();
+            int exportOperation = Utilities.getQueryType(procedure);
             // Record provenance data.
             Map<String, Object[]> tableToRowData = new HashMap<>();
-            while (rs.next()) {
+            if (!rs.next()) {
+                // Still record the query itself even if it retrieved nothing.
                 for (int colNum = 1; colNum <= rs.getMetaData().getColumnCount(); colNum++) {
                     String tableName = rs.getMetaData().getTableName(colNum);
-                    Map<String, Integer> schemaMap = getSchemaMap(tableName);
                     if (!tableToRowData.containsKey(tableName)) {
-                        Object[] rowData = new Object[4 + schemaMap.size()];
+                        Object[] rowData = new Object[4];
                         rowData[0] = txc.txID;
                         rowData[1] = timestamp;
-                        rowData[2] = Utilities.getQueryType(procedure);
+                        rowData[2] = exportOperation;
                         rowData[3] = pstmt.toString();
                         tableToRowData.put(tableName, rowData);
-                    }
-                    Object[] rowData = tableToRowData.get(tableName);
-                    String columnName = rs.getMetaData().getColumnName(colNum);
-                    if (schemaMap.containsKey(columnName)) {
-                        int index = schemaMap.get(rs.getMetaData().getColumnName(colNum));
-                        rowData[4 + index] = rs.getObject(colNum);
                     }
                 }
                 for (String tableName : tableToRowData.keySet()) {
                     workerContext.provBuff.addEntry(tableName + "Events", tableToRowData.get(tableName));
                 }
                 tableToRowData.clear();
+            } else {
+                while (rs.next()) {
+                    for (int colNum = 1; colNum <= rs.getMetaData().getColumnCount(); colNum++) {
+                        String tableName = rs.getMetaData().getTableName(colNum);
+                        Map<String, Integer> schemaMap = getSchemaMap(tableName);
+                        if (!tableToRowData.containsKey(tableName)) {
+                            Object[] rowData = new Object[4 + schemaMap.size()];
+                            rowData[0] = txc.txID;
+                            rowData[1] = timestamp;
+                            rowData[2] = exportOperation;
+                            rowData[3] = pstmt.toString();
+                            tableToRowData.put(tableName, rowData);
+                        }
+                        Object[] rowData = tableToRowData.get(tableName);
+                        String columnName = rs.getMetaData().getColumnName(colNum);
+                        if (schemaMap.containsKey(columnName)) {
+                            int index = schemaMap.get(rs.getMetaData().getColumnName(colNum));
+                            rowData[4 + index] = rs.getObject(colNum);
+                        }
+                    }
+                    for (String tableName : tableToRowData.keySet()) {
+                        workerContext.provBuff.addEntry(tableName + "Events", tableToRowData.get(tableName));
+                    }
+                    tableToRowData.clear();
+                }
             }
             rs.beforeFirst();
         }

--- a/src/main/java/org/dbos/apiary/procedures/postgres/tests/PostgresProvenanceBasic.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/tests/PostgresProvenanceBasic.java
@@ -14,6 +14,9 @@ public class PostgresProvenanceBasic extends PostgresFunction {
 
     public static int runFunction(PostgresContext ctxt, int key, int baseValue) throws Exception {
         if (key == 1) {
+            // The first query should return null.
+            ResultSet r = ctxt.executeQuery(getValue, key);
+            assert (!r.next());
             ctxt.executeUpdate(addEntry, key, baseValue);
             return baseValue+1;
         } else {

--- a/src/test/java/org/dbos/apiary/PostgresTests.java
+++ b/src/test/java/org/dbos/apiary/PostgresTests.java
@@ -301,11 +301,22 @@ public class PostgresTests {
         rs = stmt.executeQuery(String.format("SELECT * FROM %s ORDER BY %s;", table, ProvenanceBuffer.PROV_APIARY_TIMESTAMP));
         rs.next();
 
-        // Should be an insert for key=1.
+        // Should be a lookup for key=1. But with NULL data.
         long resTxid = rs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
         int resExportOp = rs.getInt(ProvenanceBuffer.PROV_APIARY_OPERATION_TYPE);
         int resKey = rs.getInt("KVKey");
+        assertTrue(rs.wasNull());
         int resValue = rs.getInt("KVValue");
+        assertEquals(txid2, resTxid);
+        assertTrue(rs.wasNull());
+        assertEquals(ProvenanceBuffer.ExportOperation.READ.getValue(), resExportOp);
+
+        rs.next();
+        // Should be an insert for key=1.
+        resTxid = rs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
+        resExportOp = rs.getInt(ProvenanceBuffer.PROV_APIARY_OPERATION_TYPE);
+        resKey = rs.getInt("KVKey");
+        resValue = rs.getInt("KVValue");
         assertEquals(txid2, resTxid);
         assertEquals(ProvenanceBuffer.ExportOperation.INSERT.getValue(), resExportOp);
         assertEquals(1, resKey);

--- a/src/test/java/org/dbos/apiary/PostgresTests.java
+++ b/src/test/java/org/dbos/apiary/PostgresTests.java
@@ -298,6 +298,7 @@ public class PostgresTests {
 
         // Check KVTable.
         table = "KVTableEvents";
+        int expectedSeqNum = 0;
         rs = stmt.executeQuery(String.format("SELECT * FROM %s ORDER BY %s;", table, ProvenanceBuffer.PROV_APIARY_TIMESTAMP));
         rs.next();
 
@@ -307,8 +308,11 @@ public class PostgresTests {
         int resKey = rs.getInt("KVKey");
         assertTrue(rs.wasNull());
         int resValue = rs.getInt("KVValue");
-        assertEquals(txid2, resTxid);
         assertTrue(rs.wasNull());
+        int resSeqNum = rs.getInt(ProvenanceBuffer.PROV_QUERY_SEQNUM);
+        assertEquals(expectedSeqNum, resSeqNum);
+        expectedSeqNum += 1;
+        assertEquals(txid2, resTxid);
         assertEquals(ProvenanceBuffer.ExportOperation.READ.getValue(), resExportOp);
 
         rs.next();
@@ -317,6 +321,9 @@ public class PostgresTests {
         resExportOp = rs.getInt(ProvenanceBuffer.PROV_APIARY_OPERATION_TYPE);
         resKey = rs.getInt("KVKey");
         resValue = rs.getInt("KVValue");
+        resSeqNum = rs.getInt(ProvenanceBuffer.PROV_QUERY_SEQNUM);
+        assertEquals(expectedSeqNum, resSeqNum);
+        expectedSeqNum += 1;
         assertEquals(txid2, resTxid);
         assertEquals(ProvenanceBuffer.ExportOperation.INSERT.getValue(), resExportOp);
         assertEquals(1, resKey);
@@ -329,6 +336,9 @@ public class PostgresTests {
         resExportOp = rs.getInt(ProvenanceBuffer.PROV_APIARY_OPERATION_TYPE);
         resKey = rs.getInt("KVKey");
         resValue = rs.getInt("KVValue");
+        resSeqNum = rs.getInt(ProvenanceBuffer.PROV_QUERY_SEQNUM);
+        assertEquals(expectedSeqNum, resSeqNum);
+        expectedSeqNum += 1;
         assertEquals(ProvenanceBuffer.ExportOperation.INSERT.getValue(), resExportOp);
         assertEquals(key, resKey);
         assertEquals(value, resValue);
@@ -340,6 +350,9 @@ public class PostgresTests {
         resExportOp = rs.getInt(ProvenanceBuffer.PROV_APIARY_OPERATION_TYPE);
         resKey = rs.getInt("KVKey");
         resValue = rs.getInt("KVValue");
+        resSeqNum = rs.getInt(ProvenanceBuffer.PROV_QUERY_SEQNUM);
+        assertEquals(expectedSeqNum, resSeqNum);
+        expectedSeqNum += 1;
         assertEquals(ProvenanceBuffer.ExportOperation.READ.getValue(), resExportOp);
         assertEquals(key, resKey);
         assertEquals(100, resValue);
@@ -351,6 +364,9 @@ public class PostgresTests {
         resExportOp = rs.getInt(ProvenanceBuffer.PROV_APIARY_OPERATION_TYPE);
         resKey = rs.getInt("KVKey");
         resValue = rs.getInt("KVValue");
+        resSeqNum = rs.getInt(ProvenanceBuffer.PROV_QUERY_SEQNUM);
+        assertEquals(expectedSeqNum, resSeqNum);
+        expectedSeqNum += 1;
         assertEquals(ProvenanceBuffer.ExportOperation.UPDATE.getValue(), resExportOp);
         assertEquals(key, resKey);
         assertEquals(value+1, resValue);
@@ -362,6 +378,9 @@ public class PostgresTests {
         resExportOp = rs.getInt(ProvenanceBuffer.PROV_APIARY_OPERATION_TYPE);
         resKey = rs.getInt("KVKey");
         resValue = rs.getInt("KVValue");
+        resSeqNum = rs.getInt(ProvenanceBuffer.PROV_QUERY_SEQNUM);
+        assertEquals(expectedSeqNum, resSeqNum);
+        expectedSeqNum += 1;
         assertEquals(ProvenanceBuffer.ExportOperation.READ.getValue(), resExportOp);
         assertEquals(key, resKey);
         assertEquals(101, resValue);
@@ -373,6 +392,8 @@ public class PostgresTests {
         resExportOp = rs.getInt(ProvenanceBuffer.PROV_APIARY_OPERATION_TYPE);
         resKey = rs.getInt("KVKey");
         resValue = rs.getInt("KVValue");
+        resSeqNum = rs.getInt(ProvenanceBuffer.PROV_QUERY_SEQNUM);
+        assertEquals(expectedSeqNum, resSeqNum);
         assertEquals(ProvenanceBuffer.ExportOperation.DELETE.getValue(), resExportOp);
         assertEquals(key, resKey);
         assertEquals(value+1, resValue);


### PR DESCRIPTION
Capture more information:
1. Capture the raw query even if it returns no records. This is useful when auditing/debugging what queries were run before.
2. Capture a query sequence number within each transaction. This is useful when a transaction has multiple queries and we can easily differentiate them.