### PR TITLE
Mysql XDST Fixes

### DIFF
--- a/src/main/java/org/dbos/apiary/mysql/MysqlConnection.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlConnection.java
@@ -18,6 +18,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
@@ -31,19 +32,25 @@ public class MysqlConnection implements ApiarySecondaryConnection {
 
     private final MysqlDataSource ds;
     private final ThreadLocal<Connection> connection;
-    private final ThreadLocal<Connection> commitConnection;
-    private boolean delayLogFlush = false;
+    private boolean delayLogFlush = true;
     private final Map<String, Map<String, Set<Long>>> committedWrites = new ConcurrentHashMap<>();
     private final Lock validationLock = new ReentrantLock();
 
+    private final Map<String, Map<String, AtomicBoolean>> lockManager = new ConcurrentHashMap<>();
+
+
     public void enableDelayedFlush() {
-        this.delayLogFlush = true;
         try {
             Connection conn = ds.getConnection();
             conn.setAutoCommit(true);
             Statement s = conn.createStatement();
-            s.execute("SET GLOBAL innodb_flush_log_at_trx_commit=0;");
+            if (delayLogFlush && ApiaryConfig.XDBTransactions) {
+                s.execute("SET GLOBAL innodb_flush_log_at_trx_commit=0;");
+            } else {
+                s.execute("SET GLOBAL innodb_flush_log_at_trx_commit=1;");
+            }
             s.close();
+            conn.close();
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -58,31 +65,19 @@ public class MysqlConnection implements ApiarySecondaryConnection {
         this.ds.setUser(databaseUsername);
         this.ds.setPassword(databasePassword);
 
+        // Enable delayed flush by default.
+        enableDelayedFlush();
+
         this.connection = ThreadLocal.withInitial(() -> {
             try {
                 Connection conn = ds.getConnection();
-                conn.setAutoCommit(true);
-                // conn.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
-                return conn;
-            } catch (SQLException e) {
-                e.printStackTrace();
-            }
-            return null;
-        });
-
-        this.commitConnection = ThreadLocal.withInitial(() -> {
-            try {
-                Connection conn = ds.getConnection();
-                conn.setAutoCommit(true);
-                if (delayLogFlush) {
-                    Statement s = conn.createStatement();
-                    s.execute("SET GLOBAL innodb_flush_log_at_trx_commit=0;");
-                    s.close();
+                if (ApiaryConfig.XDBTransactions) {
+                    conn.setAutoCommit(true);
                 } else {
-                    Statement s = conn.createStatement();
-                    s.execute("SET GLOBAL innodb_flush_log_at_trx_commit=1;");
-                    s.close();
+                    // Otherwise, manually commit transactions after function execution.
+                    conn.setAutoCommit(false);
                 }
+                // MySQL default level is repeatable read.
                 // conn.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
                 return conn;
             } catch (SQLException e) {
@@ -137,12 +132,13 @@ public class MysqlConnection implements ApiarySecondaryConnection {
 
     @Override
     public FunctionOutput callFunction(String functionName, Map<String, List<String>> writtenKeys, WorkerContext workerContext, TransactionContext txc, String service, long execID, long functionID, Object... inputs) throws Exception {
-        MysqlContext ctxt = new MysqlContext(this.connection.get(), writtenKeys, workerContext, txc, service, execID, functionID, upserts, queries);
+        MysqlContext ctxt = new MysqlContext(this.connection.get(), writtenKeys, lockManager, workerContext, txc, service, execID, functionID, upserts, queries);
         FunctionOutput f = null;
-        try {
-            f = workerContext.getFunction(functionName).apiaryRunFunction(ctxt, inputs);
-        } catch (Exception e) {
-            e.printStackTrace();
+        f = workerContext.getFunction(functionName).apiaryRunFunction(ctxt, inputs);
+
+        // Flush logs and commit transaction for non-XDST calls.
+        if (!ApiaryConfig.XDBTransactions) {
+            this.connection.get().commit();
         }
         return f;
     }
@@ -152,20 +148,25 @@ public class MysqlConnection implements ApiarySecondaryConnection {
         String query = "";
         try {
             Connection c = ds.getConnection();
+            c.setAutoCommit(false);
             Statement s = c.createStatement();
             for (String table : writtenKeys.keySet()) {
                 query = String.format("DELETE FROM %s WHERE %s = %d", table, MysqlContext.beginVersion, txc.txID);
                 s.addBatch(query);
                 query = String.format("UPDATE %s SET %s = %d where %s = %d", table, MysqlContext.endVersion, Long.MAX_VALUE, MysqlContext.endVersion, txc.txID);
                 s.addBatch(query);
+                for (String key: writtenKeys.get(table)) {
+                    lockManager.get(table).get(key).set(false);
+                }
             }
             s.executeBatch();
             s.close();
+            c.commit();
             c.close();
         } catch (Exception e) {
             e.printStackTrace();
-            logger.error("Failed to rollback txn {}", txc.txID);
-            logger.info("Rollback query: {}", query);
+            logger.error("Failed to rollback MySQL txn {}", txc.txID);
+            logger.info("Rollback MySQL query: {}", query);
         }
     }
 
@@ -198,19 +199,7 @@ public class MysqlConnection implements ApiarySecondaryConnection {
         }
         validationLock.unlock();
         if (valid) {
-            String query = "";
-            Connection c = null;
-            Statement s = null;
-            try {
-                c = commitConnection.get();
-                s = c.createStatement();
-                if (delayLogFlush) {
-                    s.execute("FLUSH ENGINE LOGS;");
-                }
-                s.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            flushEngineLogs();
         }
         long time = System.nanoTime() - t0;
         commits.add(time / 1000);
@@ -219,7 +208,11 @@ public class MysqlConnection implements ApiarySecondaryConnection {
 
     @Override
     public void commit(Map<String, List<String>> writtenKeys, TransactionContext txc) {
-
+        for (String table : writtenKeys.keySet()) {
+            for (String key : writtenKeys.get(table)) {
+                lockManager.get(table).get(key).set(false);
+            }
+        }
     }
 
     @Override
@@ -231,14 +224,32 @@ public class MysqlConnection implements ApiarySecondaryConnection {
         String query = "";
         try {
             Connection c = ds.getConnection();
+            c.setAutoCommit(false);
             Statement s = c.createStatement();
-            for (String tableName : committedWrites.keySet()) {
+            for (String tableName : lockManager.keySet()) {
                 query = String.format("DELETE FROM %s WHERE %s < %d", tableName, MysqlContext.endVersion, globalxmin);
                 s.execute(query);
             }
+            c.commit();
+            s.close();
+            c.close();
         } catch (Exception e) {
             e.printStackTrace();
             logger.error("Failed to garbage collect: {}", query);
+        }
+    }
+
+    private void flushEngineLogs() {
+        // Flush the engine.
+        Connection c = connection.get();
+        if (delayLogFlush) {
+            try {
+                Statement s = c.createStatement();
+                s.execute("FLUSH ENGINE LOGS;");
+                s.close();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
     }
 }

--- a/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
@@ -152,6 +152,8 @@ public class MysqlContext extends ApiaryContext {
         filterQuery.append(String.format(" AND (( %s < %d ", beginVersion, txc.xmax));
         if (!activeTxnString.isEmpty()) {
             filterQuery.append(String.format(" AND %s NOT IN (%s) ) ", beginVersion, activeTxnString));
+        } else {
+            filterQuery.append(" )");
         }
         // If it has updates, then need to read its own writes.
         if (mysqlUpdated) {
@@ -163,6 +165,8 @@ public class MysqlContext extends ApiaryContext {
         filterQuery.append(String.format(" AND ( %s >= %d ", endVersion, txc.xmax));
         if (!activeTxnString.isEmpty()) {
             filterQuery.append(String.format(" OR %s IN (%s) )", endVersion, activeTxnString));
+        } else {
+            filterQuery.append(" )");
         }
 
         // If it has updates, then need to read its own writes.

--- a/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
@@ -179,7 +179,6 @@ public class MysqlContext extends ApiaryContext {
         PreparedStatement pstmt = conn.prepareStatement(filterQuery.toString());
         prepareStatement(pstmt, input);
 
-        logger.debug(pstmt.toString());
         rs = pstmt.executeQuery();
 
         Long time = System.nanoTime() - t0;

--- a/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
@@ -157,7 +157,7 @@ public class MysqlContext extends ApiaryContext {
         }
         // If it has updates, then need to read its own writes.
         if (mysqlUpdated) {
-            filterQuery.append(String.format(" OR %s == %d )", beginVersion, txc.txID));
+            filterQuery.append(String.format(" OR %s = %d )", beginVersion, txc.txID));
         } else {
             filterQuery.append(")");
         }

--- a/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
@@ -73,6 +73,15 @@ public class MysqlContext extends ApiaryContext {
         }
     }
 
+    // Note: this executeUpdate should only be used by non-XDST transactions.
+    // XDST transactions must use executeUpsert.
+    public void executeUpdate(String procedure, Object... input) throws Exception {
+        assert (!ApiaryConfig.XDBTransactions);
+        PreparedStatement pstmt = conn.prepareStatement(procedure);
+        prepareStatement(pstmt, input);
+        pstmt.executeUpdate();
+    }
+
     public void executeUpsert(String tableName, String id, Object... input) throws Exception {
         long t0 = System.nanoTime();
         if (!ApiaryConfig.XDBTransactions) {

--- a/src/main/java/org/dbos/apiary/procedures/mysql/MysqlReplacePerson.java
+++ b/src/main/java/org/dbos/apiary/procedures/mysql/MysqlReplacePerson.java
@@ -12,7 +12,7 @@ public class MysqlReplacePerson extends MysqlFunction {
         if (ApiaryConfig.XDBTransactions) {
             context.executeUpsert("PersonTable", name, name, number);
         } else {
-            context.executeUpdate(nontxnUpdate, name, number);
+            context.executeUpdate(nontxnUpdate, number, name);
         }
         return number;
     }

--- a/src/main/java/org/dbos/apiary/procedures/mysql/MysqlReplacePerson.java
+++ b/src/main/java/org/dbos/apiary/procedures/mysql/MysqlReplacePerson.java
@@ -1,0 +1,19 @@
+package org.dbos.apiary.procedures.mysql;
+
+import org.dbos.apiary.mysql.MysqlContext;
+import org.dbos.apiary.mysql.MysqlFunction;
+import org.dbos.apiary.utilities.ApiaryConfig;
+
+public class MysqlReplacePerson extends MysqlFunction {
+
+    private final static String nontxnUpdate = "UPDATE PersonTable SET Number=? WHERE Name=?;";
+
+    public static int runFunction(MysqlContext context, String name, int number) throws Exception {
+        if (ApiaryConfig.XDBTransactions) {
+            context.executeUpsert("PersonTable", name, name, number);
+        } else {
+            context.executeUpdate(nontxnUpdate, name, number);
+        }
+        return number;
+    }
+}

--- a/src/main/java/org/dbos/apiary/procedures/mysql/MysqlUpsertPerson.java
+++ b/src/main/java/org/dbos/apiary/procedures/mysql/MysqlUpsertPerson.java
@@ -2,11 +2,17 @@ package org.dbos.apiary.procedures.mysql;
 
 import org.dbos.apiary.mysql.MysqlContext;
 import org.dbos.apiary.mysql.MysqlFunction;
+import org.dbos.apiary.utilities.ApiaryConfig;
 
 public class MysqlUpsertPerson extends MysqlFunction {
 
+    private final static String nontxnUpdate = "INSERT INTO PersonTable VALUES (?, ?) ON DUPLICATE KEY UPDATE Number=VALUES(Number);";
     public static int runFunction(MysqlContext context, String name, int number) throws Exception {
-        context.executeUpsert("PersonTable", name, name, number);
+        if (ApiaryConfig.XDBTransactions) {
+            context.executeUpsert("PersonTable", name, name, number);
+        } else {
+            context.executeUpdate(nontxnUpdate, name, number);
+        }
         return number;
     }
 }

--- a/src/main/java/org/dbos/apiary/procedures/mysql/MysqlWriteReadPerson.java
+++ b/src/main/java/org/dbos/apiary/procedures/mysql/MysqlWriteReadPerson.java
@@ -2,16 +2,21 @@ package org.dbos.apiary.procedures.mysql;
 
 import org.dbos.apiary.mysql.MysqlContext;
 import org.dbos.apiary.mysql.MysqlFunction;
+import org.dbos.apiary.utilities.ApiaryConfig;
 
 import java.sql.ResultSet;
 
 public class MysqlWriteReadPerson extends MysqlFunction {
     // Test read your own writes.
-
+    private final static String nontxnUpdate = "INSERT INTO PersonTable VALUES (?, ?) ON DUPLICATE KEY UPDATE Number=VALUES(Number);";
     private final static String find = "SELECT Number FROM PersonTable WHERE Name=? ;";
 
     public static int runFunction(MysqlContext context, String name, int number) throws Exception {
-        context.executeUpsert("PersonTable", name, name, number);
+        if (ApiaryConfig.XDBTransactions) {
+            context.executeUpsert("PersonTable", name, name, number);
+        } else {
+            context.executeUpdate(nontxnUpdate, name, number);
+        }
 
         ResultSet rs = context.executeQuery(find, name);
         int count = -1;  // Default not found.

--- a/src/main/java/org/dbos/apiary/procedures/mysql/MysqlWriteReadPerson.java
+++ b/src/main/java/org/dbos/apiary/procedures/mysql/MysqlWriteReadPerson.java
@@ -1,0 +1,24 @@
+package org.dbos.apiary.procedures.mysql;
+
+import org.dbos.apiary.mysql.MysqlContext;
+import org.dbos.apiary.mysql.MysqlFunction;
+
+import java.sql.ResultSet;
+
+public class MysqlWriteReadPerson extends MysqlFunction {
+    // Test read your own writes.
+
+    private final static String find = "SELECT Number FROM PersonTable WHERE Name=? ;";
+
+    public static int runFunction(MysqlContext context, String name, int number) throws Exception {
+        context.executeUpsert("PersonTable", name, name, number);
+
+        ResultSet rs = context.executeQuery(find, name);
+        int count = -1;  // Default not found.
+        if (rs.next()) {
+            count = rs.getInt(1);
+            assert (!rs.next());  // Should only have at most 1 row.
+        }
+        return count;
+    }
+}

--- a/src/main/java/org/dbos/apiary/procedures/postgres/pgmysql/PostgresMysqlReplacePerson.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/pgmysql/PostgresMysqlReplacePerson.java
@@ -1,0 +1,15 @@
+package org.dbos.apiary.procedures.postgres.pgmysql;
+
+import org.dbos.apiary.postgres.PostgresContext;
+import org.dbos.apiary.postgres.PostgresFunction;
+
+public class PostgresMysqlReplacePerson extends PostgresFunction {
+
+    private static final String insert = "INSERT INTO PersonTable(Name, Number) VALUES (?, ?) ON CONFLICT (Name) DO UPDATE SET Number = EXCLUDED.Number;";
+
+    public static int runFunction(PostgresContext ctxt, String name, int number) throws Exception {
+        ctxt.apiaryCallFunction("MysqlReplacePerson", name, number);
+        ctxt.executeUpdate(insert, name, number);
+        return number;
+    }
+}

--- a/src/main/java/org/dbos/apiary/procedures/postgres/pgmysql/PostgresMysqlWriteReadPerson.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/pgmysql/PostgresMysqlWriteReadPerson.java
@@ -1,0 +1,11 @@
+package org.dbos.apiary.procedures.postgres.pgmysql;
+
+import org.dbos.apiary.postgres.PostgresContext;
+import org.dbos.apiary.postgres.PostgresFunction;
+
+public class PostgresMysqlWriteReadPerson extends PostgresFunction {
+
+    public static int runFunction(PostgresContext ctxt, String name, int number) throws Exception {
+        return ctxt.apiaryCallFunction("MysqlWriteReadPerson", name, number).getInt();
+    }
+}

--- a/src/test/java/org/dbos/apiary/PostgresMysqlTests.java
+++ b/src/test/java/org/dbos/apiary/PostgresMysqlTests.java
@@ -6,8 +6,10 @@ import org.dbos.apiary.client.ApiaryWorkerClient;
 import org.dbos.apiary.mysql.MysqlConnection;
 import org.dbos.apiary.postgres.PostgresConnection;
 import org.dbos.apiary.procedures.mysql.MysqlQueryPerson;
+import org.dbos.apiary.procedures.mysql.MysqlReplacePerson;
 import org.dbos.apiary.procedures.mysql.MysqlUpsertPerson;
 import org.dbos.apiary.procedures.mysql.MysqlWriteReadPerson;
+import org.dbos.apiary.procedures.postgres.pgmysql.PostgresMysqlReplacePerson;
 import org.dbos.apiary.procedures.postgres.pgmysql.PostgresMysqlWriteReadPerson;
 import org.dbos.apiary.procedures.postgres.pgmysql.PostgresQueryPerson;
 import org.dbos.apiary.procedures.postgres.pgmysql.PostgresUpsertPerson;
@@ -123,7 +125,9 @@ public class PostgresMysqlTests {
         apiaryWorker.registerConnection(ApiaryConfig.postgres, pconn);
         apiaryWorker.registerFunction("PostgresUpsertPerson", ApiaryConfig.postgres, PostgresUpsertPerson::new);
         apiaryWorker.registerFunction("PostgresQueryPerson", ApiaryConfig.postgres, PostgresQueryPerson::new);
+        apiaryWorker.registerFunction("PostgresReplacePerson", ApiaryConfig.postgres, PostgresMysqlReplacePerson::new);
         apiaryWorker.registerFunction("MysqlUpsertPerson", ApiaryConfig.mysql, MysqlUpsertPerson::new);
+        apiaryWorker.registerFunction("MysqlReplacePerson", ApiaryConfig.mysql, MysqlReplacePerson::new);
         apiaryWorker.registerFunction("MysqlQueryPerson", ApiaryConfig.mysql, MysqlQueryPerson::new);
 
         apiaryWorker.startServing();
@@ -137,7 +141,7 @@ public class PostgresMysqlTests {
         res = client.executeFunction("PostgresQueryPerson", "matei").getInt();
         assertEquals(1, res);
 
-        res = client.executeFunction("PostgresUpsertPerson", "matei", 2).getInt();
+        res = client.executeFunction("PostgresReplacePerson", "matei", 2).getInt();
         assertEquals(2, res);
 
         res = client.executeFunction("PostgresQueryPerson", "matei").getInt();

--- a/src/test/java/org/dbos/apiary/PostgresMysqlTests.java
+++ b/src/test/java/org/dbos/apiary/PostgresMysqlTests.java
@@ -62,8 +62,12 @@ public class PostgresMysqlTests {
         try {
             MysqlConnection conn = new MysqlConnection("localhost", ApiaryConfig.mysqlPort, "dbos", "root", "dbos");
             conn.dropTable("PersonTable");
-            // TODO: need to solve the primary key issue. Currently cannot have primary keys.
-            conn.createTable("PersonTable", "Name varchar(1000) NOT NULL, Number integer NOT NULL");
+            if (ApiaryConfig.XDBTransactions) {
+                // TODO: need to solve the primary key issue. Currently cannot have primary keys.
+                conn.createTable("PersonTable", "Name varchar(1000) NOT NULL, Number integer NOT NULL");
+            } else {
+                conn.createTable("PersonTable", "Name varchar(1000) PRIMARY KEY NOT NULL, Number integer NOT NULL");
+            }
         } catch (Exception e) {
             logger.info("Failed to connect to MySQL.");
             assumeTrue(false);

--- a/src/test/java/org/dbos/apiary/PostgresMysqlTests.java
+++ b/src/test/java/org/dbos/apiary/PostgresMysqlTests.java
@@ -64,9 +64,9 @@ public class PostgresMysqlTests {
             conn.dropTable("PersonTable");
             if (ApiaryConfig.XDBTransactions) {
                 // TODO: need to solve the primary key issue. Currently cannot have primary keys.
-                conn.createTable("PersonTable", "Name varchar(1000) NOT NULL, Number integer NOT NULL");
+                conn.createTable("PersonTable", "Name varchar(100) NOT NULL, Number integer NOT NULL");
             } else {
-                conn.createTable("PersonTable", "Name varchar(1000) PRIMARY KEY NOT NULL, Number integer NOT NULL");
+                conn.createTable("PersonTable", "Name varchar(100) PRIMARY KEY NOT NULL, Number integer NOT NULL");
             }
         } catch (Exception e) {
             logger.info("Failed to connect to MySQL.");

--- a/src/test/java/org/dbos/apiary/PostgresMysqlTests.java
+++ b/src/test/java/org/dbos/apiary/PostgresMysqlTests.java
@@ -171,6 +171,8 @@ public class PostgresMysqlTests {
 
     @Test
     public void testMysqlConcurrentInsert() throws InterruptedException, SQLException {
+        // Only test if it's using XDBT.
+        assumeTrue(ApiaryConfig.XDBTransactions);
         logger.info("testMysqlConcurrentInsert");
 
         MysqlConnection conn = new MysqlConnection("localhost", ApiaryConfig.mysqlPort, "dbos", "root", "dbos");
@@ -225,6 +227,8 @@ public class PostgresMysqlTests {
 
     @Test
     public void testMysqlConcurrentUpdates() throws InterruptedException, SQLException {
+        // Only test if it's using XDBT.
+        assumeTrue(ApiaryConfig.XDBTransactions);
         logger.info("testMysqlConcurrentUpdates");
 
         MysqlConnection conn = new MysqlConnection("localhost", ApiaryConfig.mysqlPort, "dbos", "root", "dbos");
@@ -254,7 +258,7 @@ public class PostgresMysqlTests {
                     int localTag = ThreadLocalRandom.current().nextInt(maxTag);
                     int localCount = count.getAndIncrement();
                     client.executeFunction("PostgresUpsertPerson", "matei" + localTag, localCount).getInt();
-                    String search = "matei" + localTag;
+                    String search = "matei" + ThreadLocalRandom.current().nextInt(localTag - 5, localTag + 5);
                     int res = client.executeFunction("PostgresQueryPerson", search).getInt();
                     if (res == -1) {
                         success.set(false);


### PR DESCRIPTION
This PR fixed a bunch of things:
- Correctly use write locks to protect updates, and fix read-your-writes issues including the read predicate and retry logic for visibility.
- Add support for non-XDST transactions in MySQL.
- Update tests.

Will implement MySQL microbenchmark in the next PR.