### PR TITLE
Retro replay

### DIFF
--- a/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
+++ b/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
@@ -142,7 +142,7 @@ public class RetroBenchmark {
 
             pgConn.dropTable("ForumSubscription");
             pgConn.createTable("ForumSubscription", "UserId integer NOT NULL, ForumId integer NOT NULL");
-            pgConn.dropTable(ProvenanceBuffer.PROV_FuncInvocations);
+            pgConn.dropTable(ApiaryConfig.tableFuncInvocations);
             pgConn.dropTable(ProvenanceBuffer.PROV_ApiaryMetadata);
             pgConn.dropTable(ProvenanceBuffer.PROV_QueryMetadata);
         } catch (Exception e) {

--- a/src/main/java/org/dbos/apiary/client/ApiaryWorkerClient.java
+++ b/src/main/java/org/dbos/apiary/client/ApiaryWorkerClient.java
@@ -1,7 +1,6 @@
 package org.dbos.apiary.client;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import org.dbos.apiary.function.ApiaryContext;
 import org.dbos.apiary.function.FunctionOutput;
 import org.dbos.apiary.utilities.ApiaryConfig;
 import org.slf4j.Logger;
@@ -83,7 +82,7 @@ public class ApiaryWorkerClient {
     }
 
     /**
-     * Replay a function synchronously and block waiting for the result. The replay will not generate new provenance data.
+     * Replay a single function/workflow synchronously and block waiting for the result. The replay will not generate new provenance data.
      * @param execId    the original execution ID of the invoked function.
      * @param name      the name of the invoked function.
      * @param arguments the original arguments of the invoked function.
@@ -91,6 +90,11 @@ public class ApiaryWorkerClient {
      * @throws InvalidProtocolBufferException
      */
     public FunctionOutput replayFunction(long execId, String name, Object... arguments) throws InvalidProtocolBufferException {
+        return internalClient.executeFunction(this.apiaryWorkerAddress, name, "DefaultService", execId, ApiaryConfig.ReplayMode.SINGLE.getValue(), arguments);
+    }
+
+
+    public FunctionOutput retroReplay(long execId, String name, Object... arguments) throws InvalidProtocolBufferException {
         return internalClient.executeFunction(this.apiaryWorkerAddress, name, "DefaultService", execId, ApiaryConfig.ReplayMode.SINGLE.getValue(), arguments);
     }
 

--- a/src/main/java/org/dbos/apiary/client/ApiaryWorkerClient.java
+++ b/src/main/java/org/dbos/apiary/client/ApiaryWorkerClient.java
@@ -94,8 +94,8 @@ public class ApiaryWorkerClient {
     }
 
 
-    public FunctionOutput retroReplay(long execId, String name, Object... arguments) throws InvalidProtocolBufferException {
-        return internalClient.executeFunction(this.apiaryWorkerAddress, name, "DefaultService", execId, ApiaryConfig.ReplayMode.SINGLE.getValue(), arguments);
+    public FunctionOutput retroReplay(long execId) throws InvalidProtocolBufferException {
+        return internalClient.executeFunction(this.apiaryWorkerAddress, "retroReplay", "DefaultService", execId, ApiaryConfig.ReplayMode.ALL.getValue(), null);
     }
 
     /**

--- a/src/main/java/org/dbos/apiary/client/ApiaryWorkerClient.java
+++ b/src/main/java/org/dbos/apiary/client/ApiaryWorkerClient.java
@@ -1,7 +1,9 @@
 package org.dbos.apiary.client;
 
 import com.google.protobuf.InvalidProtocolBufferException;
+import org.dbos.apiary.function.ApiaryContext;
 import org.dbos.apiary.function.FunctionOutput;
+import org.dbos.apiary.utilities.ApiaryConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.zeromq.*;
@@ -42,7 +44,7 @@ public class ApiaryWorkerClient {
         this.internalClient = new InternalApiaryWorkerClient(zContext);
         int tmpID = 0;
         try {
-            tmpID = internalClient.executeFunction(this.apiaryWorkerAddress, getApiaryClientID, "ApiarySystem", 0L, false).getInt();
+            tmpID = internalClient.executeFunction(this.apiaryWorkerAddress, getApiaryClientID, "ApiarySystem", 0L, ApiaryConfig.ReplayMode.NOT_REPLAY.getValue()).getInt();
         } catch (InvalidProtocolBufferException e) {
             e.printStackTrace();
         }
@@ -66,7 +68,7 @@ public class ApiaryWorkerClient {
      * @return          serialized byte array of the request.
      */
     public byte[] serializeExecuteRequest(String name, String service, Object... arguments) {
-        return InternalApiaryWorkerClient.serializeExecuteRequest(name, service, getExecutionId(), false, 0L, 0L, arguments);
+        return InternalApiaryWorkerClient.serializeExecuteRequest(name, service, getExecutionId(), ApiaryConfig.ReplayMode.NOT_REPLAY.getValue(), 0L, 0L, arguments);
     }
 
     /**
@@ -77,7 +79,7 @@ public class ApiaryWorkerClient {
      * @throws InvalidProtocolBufferException
      */
     public FunctionOutput executeFunction(String name, Object... arguments) throws InvalidProtocolBufferException {
-        return internalClient.executeFunction(this.apiaryWorkerAddress, name, "DefaultService", getExecutionId(), false, arguments);
+        return internalClient.executeFunction(this.apiaryWorkerAddress, name, "DefaultService", getExecutionId(), ApiaryConfig.ReplayMode.NOT_REPLAY.getValue(), arguments);
     }
 
     /**
@@ -89,7 +91,7 @@ public class ApiaryWorkerClient {
      * @throws InvalidProtocolBufferException
      */
     public FunctionOutput replayFunction(long execId, String name, Object... arguments) throws InvalidProtocolBufferException {
-        return internalClient.executeFunction(this.apiaryWorkerAddress, name, "DefaultService", execId, true, arguments);
+        return internalClient.executeFunction(this.apiaryWorkerAddress, name, "DefaultService", execId, ApiaryConfig.ReplayMode.SINGLE.getValue(), arguments);
     }
 
     /**

--- a/src/main/java/org/dbos/apiary/client/ApiaryWorkerClient.java
+++ b/src/main/java/org/dbos/apiary/client/ApiaryWorkerClient.java
@@ -93,7 +93,12 @@ public class ApiaryWorkerClient {
         return internalClient.executeFunction(this.apiaryWorkerAddress, name, "DefaultService", execId, ApiaryConfig.ReplayMode.SINGLE.getValue(), arguments);
     }
 
-
+    /**
+     * Replay the execution and everything after it using the original execution trace. Block waiting for the result of the last execution. The replay will not generate new provenance data.
+     * @param execId    the original execution ID of the target request.
+     * @return          the output of the last execution.
+     * @throws InvalidProtocolBufferException
+     */
     public FunctionOutput retroReplay(long execId) throws InvalidProtocolBufferException {
         return internalClient.executeFunction(this.apiaryWorkerAddress, "retroReplay", "DefaultService", execId, ApiaryConfig.ReplayMode.ALL.getValue(), null);
     }

--- a/src/main/java/org/dbos/apiary/client/InternalApiaryWorkerClient.java
+++ b/src/main/java/org/dbos/apiary/client/InternalApiaryWorkerClient.java
@@ -53,25 +53,27 @@ public class InternalApiaryWorkerClient {
                                                  long callerID, long functionID, Object... arguments) {
         List<ByteString> byteArguments = new ArrayList<>();
         List<Integer> argumentTypes = new ArrayList<>();
-        for (Object o: arguments) {
-            if (o instanceof String) {
-                String s = (String) o;
-                byteArguments.add(ByteString.copyFrom(s.getBytes(StandardCharsets.UTF_8)));
-                argumentTypes.add(Utilities.stringType);
-            }  else if (o instanceof Integer) {
-                Integer i = (Integer) o;
-                byteArguments.add(ByteString.copyFrom(Utilities.toByteArray(i)));
-                argumentTypes.add(Utilities.intType);
-            }  else if (o instanceof String[]) {
-                String[] s = (String[]) o;
-                byteArguments.add(ByteString.copyFrom(Utilities.stringArraytoByteArray(s)));
-                argumentTypes.add(Utilities.stringArrayType);
-            } else if (o instanceof int[]) {
-                int[] i = (int[]) o;
-                byteArguments.add(ByteString.copyFrom(Utilities.intArrayToByteArray(i)));
-                argumentTypes.add(Utilities.intArrayType);
-            } else {
-                logger.info("Unrecognized type {}: {}", o.getClass().getName(), o);
+        if (arguments != null) {
+            for (Object o : arguments) {
+                if (o instanceof String) {
+                    String s = (String) o;
+                    byteArguments.add(ByteString.copyFrom(s.getBytes(StandardCharsets.UTF_8)));
+                    argumentTypes.add(Utilities.stringType);
+                } else if (o instanceof Integer) {
+                    Integer i = (Integer) o;
+                    byteArguments.add(ByteString.copyFrom(Utilities.toByteArray(i)));
+                    argumentTypes.add(Utilities.intType);
+                } else if (o instanceof String[]) {
+                    String[] s = (String[]) o;
+                    byteArguments.add(ByteString.copyFrom(Utilities.stringArraytoByteArray(s)));
+                    argumentTypes.add(Utilities.stringArrayType);
+                } else if (o instanceof int[]) {
+                    int[] i = (int[]) o;
+                    byteArguments.add(ByteString.copyFrom(Utilities.intArrayToByteArray(i)));
+                    argumentTypes.add(Utilities.intArrayType);
+                } else {
+                    logger.info("Unrecognized type {}: {}", o.getClass().getName(), o);
+                }
             }
         }
         long sendTime = System.nanoTime();

--- a/src/main/java/org/dbos/apiary/client/InternalApiaryWorkerClient.java
+++ b/src/main/java/org/dbos/apiary/client/InternalApiaryWorkerClient.java
@@ -49,7 +49,7 @@ public class InternalApiaryWorkerClient {
         }
     }
 
-    public static byte[] serializeExecuteRequest(String name, String service, long execID, boolean isReplay,
+    public static byte[] serializeExecuteRequest(String name, String service, long execID, int replayMode,
                                                  long callerID, long functionID, Object... arguments) {
         List<ByteString> byteArguments = new ArrayList<>();
         List<Integer> argumentTypes = new ArrayList<>();
@@ -84,15 +84,15 @@ public class InternalApiaryWorkerClient {
                 .setService(service)
                 .setExecutionId(execID)
                 .setSenderTimestampNano(sendTime)
-                .setIsReplay(isReplay)
+                .setReplayMode(replayMode)
                 .build();
         return req.toByteArray();
     }
 
-    public FunctionOutput executeFunction(String address, String name, String service, long execID, boolean isReplay,
+    public FunctionOutput executeFunction(String address, String name, String service, long execID, int replayMode,
                                           Object... arguments) throws InvalidProtocolBufferException {
         ZMQ.Socket socket = getSocket(address);
-        byte[] reqBytes = serializeExecuteRequest(name, service, execID, isReplay, 0l, 0, arguments);
+        byte[] reqBytes = serializeExecuteRequest(name, service, execID, replayMode, 0l, 0, arguments);
         socket.send(reqBytes, 0);
         byte[] replyBytes = socket.recv(0);
         ExecuteFunctionReply rep = ExecuteFunctionReply.parseFrom(replyBytes);

--- a/src/main/java/org/dbos/apiary/client/InternalApiaryWorkerClient.java
+++ b/src/main/java/org/dbos/apiary/client/InternalApiaryWorkerClient.java
@@ -57,19 +57,19 @@ public class InternalApiaryWorkerClient {
             if (o instanceof String) {
                 String s = (String) o;
                 byteArguments.add(ByteString.copyFrom(s.getBytes(StandardCharsets.UTF_8)));
-                argumentTypes.add(ApiaryWorker.stringType);
+                argumentTypes.add(Utilities.stringType);
             }  else if (o instanceof Integer) {
                 Integer i = (Integer) o;
                 byteArguments.add(ByteString.copyFrom(Utilities.toByteArray(i)));
-                argumentTypes.add(ApiaryWorker.intType);
+                argumentTypes.add(Utilities.intType);
             }  else if (o instanceof String[]) {
                 String[] s = (String[]) o;
                 byteArguments.add(ByteString.copyFrom(Utilities.stringArraytoByteArray(s)));
-                argumentTypes.add(ApiaryWorker.stringArrayType);
+                argumentTypes.add(Utilities.stringArrayType);
             } else if (o instanceof int[]) {
                 int[] i = (int[]) o;
                 byteArguments.add(ByteString.copyFrom(Utilities.intArrayToByteArray(i)));
-                argumentTypes.add(ApiaryWorker.intArrayType);
+                argumentTypes.add(Utilities.intArrayType);
             } else {
                 logger.info("Unrecognized type {}: {}", o.getClass().getName(), o);
             }

--- a/src/main/java/org/dbos/apiary/connection/ApiaryConnection.java
+++ b/src/main/java/org/dbos/apiary/connection/ApiaryConnection.java
@@ -23,7 +23,7 @@ public interface ApiaryConnection {
      * @throws Exception
      */
     FunctionOutput callFunction(String functionName, WorkerContext workerContext, String service, long execID, long functionID,
-                                boolean isReplay, Object... inputs) throws Exception;
+                                int replayMode, Object... inputs) throws Exception;
 
     Set<TransactionContext> getActiveTransactions();
 

--- a/src/main/java/org/dbos/apiary/elasticsearch/ElasticsearchContext.java
+++ b/src/main/java/org/dbos/apiary/elasticsearch/ElasticsearchContext.java
@@ -33,7 +33,7 @@ public class ElasticsearchContext extends ApiaryContext {
     private final Map<String, Map<String, AtomicBoolean>> lockManager;
 
     public ElasticsearchContext(ElasticsearchClient client, Map<String, List<String>> writtenKeys, Map<String, Map<String, AtomicBoolean>> lockManager, WorkerContext workerContext, TransactionContext txc, String service, long execID, long functionID) {
-        super(workerContext, service, execID, functionID, false);
+        super(workerContext, service, execID, functionID, ApiaryConfig.ReplayMode.NOT_REPLAY.getValue());
         this.client = client;
         this.txc = txc;
         this.lockManager = lockManager;

--- a/src/main/java/org/dbos/apiary/function/ApiaryContext.java
+++ b/src/main/java/org/dbos/apiary/function/ApiaryContext.java
@@ -1,6 +1,7 @@
 package org.dbos.apiary.function;
 
-import java.sql.SQLException;
+import org.dbos.apiary.utilities.ApiaryConfig;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -28,14 +29,14 @@ public abstract class ApiaryContext {
     /**
      * For internal use only.
      */
-    public final boolean isReplay;
+    public final int replayMode;
 
-    public ApiaryContext(WorkerContext workerContext, String service, long execID, long functionID, boolean isReplay) {
+    public ApiaryContext(WorkerContext workerContext, String service, long execID, long functionID, int replayMode) {
         this.workerContext = workerContext;
         this.service = service;
         this.execID = execID;
         this.functionID = functionID;
-        this.isReplay = isReplay;
+        this.replayMode = replayMode;
     }
 
     /** Public Interface for functions. **/

--- a/src/main/java/org/dbos/apiary/function/ApiaryStatelessContext.java
+++ b/src/main/java/org/dbos/apiary/function/ApiaryStatelessContext.java
@@ -8,8 +8,8 @@ import org.dbos.apiary.utilities.ApiaryConfig;
  */
 public class ApiaryStatelessContext extends ApiaryContext {
 
-    public ApiaryStatelessContext(WorkerContext workerContext, String service, long execID, long functionID, boolean isReplay) {
-        super(workerContext, service, execID, functionID, isReplay);
+    public ApiaryStatelessContext(WorkerContext workerContext, String service, long execID, long functionID, int replayMode) {
+        super(workerContext, service, execID, functionID, replayMode);
     }
 
     @Override
@@ -33,7 +33,7 @@ public class ApiaryStatelessContext extends ApiaryContext {
             try {
                 assert(type.equals(workerContext.getPrimaryConnectionType()));
                 ApiaryConnection c = workerContext.getPrimaryConnection();
-                return c.callFunction(name, workerContext, service, execID, functionID, isReplay, inputs);
+                return c.callFunction(name, workerContext, service, execID, functionID, replayMode, inputs);
             } catch (Exception e) {
                 e.printStackTrace();
                 return null;

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -298,10 +298,10 @@ public class ProvenanceBuffer {
                 } else if (((List<?>) val).get(0) instanceof ByteString) {
                     Object[] byteAry = new Object[sz];
                     for (int i = 0; i < sz; i++) {
-                        byte[] tmpBytes = ((List<ByteString>) val).get(i).toByteArray();
+                        String tmpBytes = ((List<ByteString>) val).get(i).toStringUtf8();
                         byteAry[i] = tmpBytes;
                     }
-                    ary = conn.createArrayOf("BYTEA", byteAry);
+                    ary = conn.createArrayOf("TEXT", byteAry);
                 } else {
                     logger.warn("Do not support such array type: {}", ((List<?>) val).get(0).getClass());
                 }

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -287,6 +287,10 @@ public class ProvenanceBuffer {
             pstmt.setString(colIndex, val.toString());
         } else if (colType == Types.ARRAY) {
             if ((val instanceof List)) {
+                if (((List<?>) val).isEmpty() {
+                    pstmt.setNull(colIndex, colType);
+                    return;
+                }
                 Array ary = null;
                 int sz = ((List<?>) val).size();
                 if (((List<?>) val).get(0) instanceof Integer) {

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -297,7 +297,19 @@ public class ProvenanceBuffer {
                 if (((List<?>) val).get(0) instanceof Integer) {
                     Array ary = conn.createArrayOf("INTEGER", ((List<?>) val).toArray());
                     pstmt.setArray(colIndex, ary);
-                } else if (((List<?>) val).get(0) instanceof ByteString) {
+                } else {
+                pstmt.setNull(colIndex, colType);
+                logger.warn("Failed to convert type: {}. Skipped and set to null.", colType);
+            }
+        } else if (colType == Types.BINARY) {
+            // The bytea type.
+            if ((val instanceof List)) {
+                if (((List<?>) val).isEmpty()) {
+                    pstmt.setNull(colIndex, colType);
+                    return;
+                }
+                int sz = ((List<?>) val).size();
+                if (((List<?>) val).get(0) instanceof ByteString) {
                     ByteArrayOutputStream outputStream = new ByteArrayOutputStream( );
                     for (int i = 0; i < sz; i++) {
                         byte[] tmpBytes = ((List<ByteString>) val).get(i).toByteArray();

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -40,6 +40,7 @@ public class ProvenanceBuffer {
     public static final String PROV_QUERY_SEQNUM = "APIARY_QUERY_SEQNUM";
     public static final String PROV_QUERY_TABLENAMES = "APIARY_QUERY_TABLENAMES";
     public static final String PROV_QUERY_PROJECTION = "APIARY_QUERY_PROJECTION";
+    public static final String PROV_REQ_BYTES = "APIARY_REQ_BYTES";
 
     /**
      * Enum class for provenance operations.

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -287,7 +287,7 @@ public class ProvenanceBuffer {
             pstmt.setString(colIndex, val.toString());
         } else if (colType == Types.ARRAY) {
             if ((val instanceof List)) {
-                if (((List<?>) val).isEmpty() {
+                if (((List<?>) val).isEmpty()) {
                     pstmt.setNull(colIndex, colType);
                     return;
                 }

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -290,10 +290,8 @@ public class ProvenanceBuffer {
             pstmt.setString(colIndex, val.toString());
         } else if (colType == Types.BINARY) {
             // The bytea type.
-            if (val instanceof com.google.protobuf.GeneratedMessageV3) {
-                // Convert protobuf to byte array.
-                byte[] varbin = ((GeneratedMessage) val).toByteArray();
-                pstmt.setBytes(colIndex, varbin);
+            if (val instanceof byte[]) {
+                pstmt.setBytes(colIndex, (byte[]) val);
             } else {
                 pstmt.setNull(colIndex, colType);
                 logger.warn("Failed to convert type: {}. Skipped and set to null.", colType);

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -298,8 +298,9 @@ public class ProvenanceBuffer {
                     Array ary = conn.createArrayOf("INTEGER", ((List<?>) val).toArray());
                     pstmt.setArray(colIndex, ary);
                 } else {
-                pstmt.setNull(colIndex, colType);
-                logger.warn("Failed to convert type: {}. Skipped and set to null.", colType);
+                    pstmt.setNull(colIndex, colType);
+                    logger.warn("Failed to convert type: {}. Skipped and set to null.", colType);
+                }
             }
         } else if (colType == Types.BINARY) {
             // The bytea type.

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -245,8 +245,7 @@ public class ProvenanceBuffer {
         logger.info("Exported table {}, {} rows", table, numEntries);
     }
 
-    private void setColumn(PreparedStatement pstmt, int colIndex, int colType, Object val) throws SQLException {
-        Connection conn = this.conn.get();
+    private static void setColumn(PreparedStatement pstmt, int colIndex, int colType, Object val) throws SQLException {
         // Convert value to the target type.
         if (val == null) {
             // The column must be nullable.
@@ -291,12 +290,7 @@ public class ProvenanceBuffer {
             pstmt.setString(colIndex, val.toString());
         } else if (colType == Types.BINARY) {
             // The bytea type.
-            if (val instanceof byte[]) {
-                pstmt.setBytes(colIndex, (byte[]) val);
-            } else {
-                pstmt.setNull(colIndex, colType);
-                logger.warn("Failed to convert type: {}. Skipped and set to null.", colType);
-            }
+            pstmt.setBytes(colIndex, (byte[]) val);
         } else {
             // Everything else will be passed directly as string.
             logger.warn(String.format("Failed to convert type: %d. Use String", colType));

--- a/src/main/java/org/dbos/apiary/gcs/GCSContext.java
+++ b/src/main/java/org/dbos/apiary/gcs/GCSContext.java
@@ -39,7 +39,7 @@ public class GCSContext extends ApiaryContext {
 
     public GCSContext(Storage storage, Map<String, List<String>> writtenKeys, Map<String, Map<String, AtomicBoolean>> lockManager, WorkerContext workerContext,
                       TransactionContext txc, String service, long execID, long functionID, Connection primary) {
-        super(workerContext, service, execID, functionID, false);
+        super(workerContext, service, execID, functionID, ApiaryConfig.ReplayMode.NOT_REPLAY.getValue());
         this.storage = storage;
         this.txc = txc;
         this.primary = primary;

--- a/src/main/java/org/dbos/apiary/mongo/MongoContext.java
+++ b/src/main/java/org/dbos/apiary/mongo/MongoContext.java
@@ -39,7 +39,7 @@ public class MongoContext extends ApiaryContext {
     final Map<String, List<String>> writtenKeys;
 
     public MongoContext(MongoClient client, Map<String, List<String>> writtenKeys, MongoDatabase database, Map<String, Map<String, AtomicBoolean>> lockManager, WorkerContext workerContext, TransactionContext txc, String service, long execID, long functionID) {
-        super(workerContext, service, execID, functionID, false);
+        super(workerContext, service, execID, functionID, ApiaryConfig.ReplayMode.NOT_REPLAY.getValue());
         this.database = database;
         this.client = client;
         this.txc = txc;

--- a/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
+++ b/src/main/java/org/dbos/apiary/mysql/MysqlContext.java
@@ -41,7 +41,7 @@ public class MysqlContext extends ApiaryContext {
     Map<String, List<String>> writtenKeys;
 
     public MysqlContext(Connection conn, Map<String, List<String>> writtenKeys, Map<String, Map<String, AtomicBoolean>> lockManager,  WorkerContext workerContext, TransactionContext txc, String service, long execID, long functionID, Percentile upserts, Percentile queries) {
-        super(workerContext, service, execID, functionID, false);
+        super(workerContext, service, execID, functionID, ApiaryConfig.ReplayMode.NOT_REPLAY.getValue());
         this.writtenKeys = writtenKeys;
         this.conn = conn;
         this.txc = txc;

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -76,7 +76,7 @@ public class PostgresConnection implements ApiaryConnection {
             logger.info("Failed to connect to Postgres");
             throw new RuntimeException("Failed to connect to Postgres");
         }
-        createTable(ProvenanceBuffer.PROV_FuncInvocations,
+        createTable(ApiaryConfig.tableFuncInvocations,
                 ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID + " BIGINT NOT NULL, "
                 + ProvenanceBuffer.PROV_APIARY_TIMESTAMP + " BIGINT NOT NULL, "
                 + ProvenanceBuffer.PROV_EXECUTIONID + " BIGINT NOT NULL, "
@@ -93,6 +93,12 @@ public class PostgresConnection implements ApiaryConnection {
                 + ProvenanceBuffer.PROV_QUERY_TABLENAMES + " VARCHAR(1024) NOT NULL, "
                 + ProvenanceBuffer.PROV_QUERY_PROJECTION + " VARCHAR(1024) NOT NULL "
         );
+
+        if (ApiaryConfig.recordInput) {
+            // Record input for replay. Only need to record the input of the first function, so we only need to use execID to find the arguments.
+            createTable(ApiaryConfig.tableRecordedInputs, "ExecID BIGINT PRIMARY KEY, ARGTYPES INTEGER[], ARGBYTES BYTEA[]");
+        }
+
         // TODO: add back recorded outputs later for fault tolerance.
         // createTable("RecordedOutputs", "ExecID bigint, FunctionID bigint, StringOutput VARCHAR(1000), IntOutput integer, StringArrayOutput bytea, IntArrayOutput bytea, FutureOutput bigint, QueuedTasks bytea, PRIMARY KEY(ExecID, FunctionID)");
     }

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -96,7 +96,10 @@ public class PostgresConnection implements ApiaryConnection {
 
         if (ApiaryConfig.recordInput) {
             // Record input for replay. Only need to record the input of the first function, so we only need to use execID to find the arguments.
-            createTable(ApiaryConfig.tableRecordedInputs, "ExecID BIGINT PRIMARY KEY, REQ_PROTO_BYTES BYTEA");
+            createTable(ApiaryConfig.tableRecordedInputs,
+                    ProvenanceBuffer.PROV_EXECUTIONID + " BIGINT PRIMARY KEY, " +
+                    ProvenanceBuffer.PROV_REQ_BYTES + " BYTEA NOT NULL");
+
         }
 
         // TODO: add back recorded outputs later for fault tolerance.

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -96,8 +96,8 @@ public class PostgresConnection implements ApiaryConnection {
 
         if (ApiaryConfig.recordInput) {
             // Record input for replay. Only need to record the input of the first function, so we only need to use execID to find the arguments.
-            // Since Postgres does not really support arrays of byte[], we have to use the string type.
-            createTable(ApiaryConfig.tableRecordedInputs, "ExecID BIGINT PRIMARY KEY, ARGTYPES INTEGER[], ARGBYTES TEXT[]");
+            // Since Postgres does not really support arrays of byte[], we have to manually parse it.
+            createTable(ApiaryConfig.tableRecordedInputs, "ExecID BIGINT PRIMARY KEY, ARGTYPES INTEGER[], ARGLENS INTEGER[], ARGBYTES BYTEA");
         }
 
         // TODO: add back recorded outputs later for fault tolerance.

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -96,8 +96,7 @@ public class PostgresConnection implements ApiaryConnection {
 
         if (ApiaryConfig.recordInput) {
             // Record input for replay. Only need to record the input of the first function, so we only need to use execID to find the arguments.
-            // Since Postgres does not really support arrays of byte[], we have to manually parse it.
-            createTable(ApiaryConfig.tableRecordedInputs, "ExecID BIGINT PRIMARY KEY, ARGTYPES INTEGER[], ARGLENS INTEGER[], ARGBYTES BYTEA");
+            createTable(ApiaryConfig.tableRecordedInputs, "ExecID BIGINT PRIMARY KEY, REQ_PROTO_BYTES BYTEA");
         }
 
         // TODO: add back recorded outputs later for fault tolerance.

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -96,7 +96,8 @@ public class PostgresConnection implements ApiaryConnection {
 
         if (ApiaryConfig.recordInput) {
             // Record input for replay. Only need to record the input of the first function, so we only need to use execID to find the arguments.
-            createTable(ApiaryConfig.tableRecordedInputs, "ExecID BIGINT PRIMARY KEY, ARGTYPES INTEGER[], ARGBYTES BYTEA[]");
+            // Since Postgres does not really support arrays of byte[], we have to use the string type.
+            createTable(ApiaryConfig.tableRecordedInputs, "ExecID BIGINT PRIMARY KEY, ARGTYPES INTEGER[], ARGBYTES TEXT[]");
         }
 
         // TODO: add back recorded outputs later for fault tolerance.

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -163,12 +163,12 @@ public class PostgresConnection implements ApiaryConnection {
 
     @Override
     public FunctionOutput callFunction(String functionName, WorkerContext workerContext, String service, long execID,
-                                       long functionID, boolean isReplay, Object... inputs) {
+                                       long functionID, int replayMode, Object... inputs) {
         Connection c = connection.get();
         FunctionOutput f = null;
         while (true) {
             activeTransactionsLock.readLock().lock();
-            PostgresContext ctxt = new PostgresContext(c, workerContext, service, execID, functionID, isReplay,
+            PostgresContext ctxt = new PostgresContext(c, workerContext, service, execID, functionID, replayMode,
                     new HashSet<>(activeTransactions), new HashSet<>(abortedTransactions));
             activeTransactions.add(ctxt.txc);
             latestTransactionContext = ctxt.txc;

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -121,6 +121,22 @@ public class PostgresConnection implements ApiaryConnection {
     }
 
     /**
+     * Truncate a table and potentially its corresponding events table.
+     * @param tableName         the table to truncate.
+     * @param deleteProvenance  if true, truncate the events table as well.
+     */
+    public void truncateTable(String tableName, boolean deleteProvenance) throws SQLException {
+        Connection conn = ds.getConnection();
+        Statement truncateTable = conn.createStatement();
+        truncateTable.execute(String.format("TRUNCATE %s;", tableName));
+        if (deleteProvenance) {
+            truncateTable.execute(String.format("TRUNCATE %sEvents;", tableName));
+        }
+        truncateTable.close();
+        conn.close();
+    }
+
+    /**
      * Create a table and a corresponding events table.
      * @param tableName the table to create.
      * @param specStr the schema of the table, in Postgres DDL.

--- a/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
@@ -141,7 +141,7 @@ public class PostgresContext extends ApiaryContext {
      */
     public void executeUpdate(String procedure, Object... input) throws SQLException {
         // Replay.
-        if (this.replayMode != ApiaryConfig.ReplayMode.NOT_REPLAY.getValue()) {
+        if (this.replayMode == ApiaryConfig.ReplayMode.SINGLE.getValue()) {
             replayUpdate(procedure, input);
             return;
         }
@@ -215,7 +215,7 @@ public class PostgresContext extends ApiaryContext {
      */
     public ResultSet executeQuery(String procedure, Object... input) throws SQLException {
         // Replay
-        if (this.replayMode != ApiaryConfig.ReplayMode.NOT_REPLAY.getValue()) {
+        if (this.replayMode == ApiaryConfig.ReplayMode.SINGLE.getValue()) {
             return replayQuery(procedure, input);
         }
         PreparedStatement pstmt = conn.prepareStatement(procedure, ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);

--- a/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
@@ -27,7 +27,7 @@ public class PostgresContext extends ApiaryContext {
     private final long replayTxID;  // The replayed transaction ID.
 
     private static final String checkReplayTxID = String.format("SELECT %s FROM %s WHERE %s=? AND %s=? AND %s=0", ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID,
-            ProvenanceBuffer.PROV_FuncInvocations, ProvenanceBuffer.PROV_EXECUTIONID, ProvenanceBuffer.PROV_FUNCID, ProvenanceBuffer.PROV_ISREPLAY);
+            ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_EXECUTIONID, ProvenanceBuffer.PROV_FUNCID, ProvenanceBuffer.PROV_ISREPLAY);
 
     private static final String checkMetadata = String.format("SELECT * FROM %s WHERE %s=? AND %s=?", ProvenanceBuffer.PROV_QueryMetadata, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID, ProvenanceBuffer.PROV_QUERY_SEQNUM);
 

--- a/src/main/java/org/dbos/apiary/postgres/PostgresFunction.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresFunction.java
@@ -15,10 +15,8 @@ public class PostgresFunction implements ApiaryFunction {
 
     @Override
     public void recordInvocation(ApiaryContext ctxt, String funcName) {
-        short isreplay = 0;
-        if (ctxt.isReplay) {
-            isreplay = 1;
-        }
+        short isreplay = (short) ctxt.replayMode;
+
         if (ctxt.workerContext.provBuff == null) {
             // If no OLAP DB available.
             return;

--- a/src/main/java/org/dbos/apiary/utilities/ApiaryConfig.java
+++ b/src/main/java/org/dbos/apiary/utilities/ApiaryConfig.java
@@ -55,4 +55,8 @@ public class ApiaryConfig {
         }
     }
 
+    public static Boolean recordInput = false;  // If true, capture input of the entry function and record in a table.
+    public static final String tableRecordedInputs = "RECORDEDINPUTS";
+
+
 }

--- a/src/main/java/org/dbos/apiary/utilities/ApiaryConfig.java
+++ b/src/main/java/org/dbos/apiary/utilities/ApiaryConfig.java
@@ -37,4 +37,22 @@ public class ApiaryConfig {
     // GCS bucket names.
     public static final String gcsTestBucket = "apiary_gcs_test";
     public static final String mysql = "mysql";
+
+    // Replay mode.
+    public enum ReplayMode {
+        NOT_REPLAY(0),
+        SINGLE(1),
+        ALL(2);
+
+        private int value;
+
+        private ReplayMode (int value) {
+            this.value = value;
+        }
+
+        public int getValue() {
+            return this.value;
+        }
+    }
+
 }

--- a/src/main/java/org/dbos/apiary/voltdb/VoltConnection.java
+++ b/src/main/java/org/dbos/apiary/voltdb/VoltConnection.java
@@ -111,7 +111,7 @@ public class VoltConnection implements ApiaryConnection {
 
     @Override
     public FunctionOutput callFunction(String functionName, WorkerContext context, String service, long execID, long functionID,
-                                       boolean isReplay, Object... inputs) throws IOException, ProcCallException {
+                                       int replayMode, Object... inputs) throws IOException, ProcCallException {
         if (functionName.startsWith(getApiaryClientID)) {
             // Add input value for the procedure.
             inputs = new Integer[1];

--- a/src/main/java/org/dbos/apiary/voltdb/VoltContext.java
+++ b/src/main/java/org/dbos/apiary/voltdb/VoltContext.java
@@ -37,7 +37,7 @@ public class VoltContext extends ApiaryContext {
     private long currentID = functionID;
 
     public VoltContext(VoltFunction p, ProvenanceBuffer provBuff, String service, long execID, long functionID) {
-        super(new WorkerContext(provBuff), service, execID, functionID, false);
+        super(new WorkerContext(provBuff), service, execID, functionID, ApiaryConfig.ReplayMode.NOT_REPLAY.getValue());
         this.p = p;
         this.transactionID = getTransactionID();
     }

--- a/src/main/java/org/dbos/apiary/worker/ApiaryTaskStash.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryTaskStash.java
@@ -21,17 +21,17 @@ public class ApiaryTaskStash {
     public final long senderTimestampNano;
     public final String service;
     public final long execId;
-    public final boolean isReplay;
+    public final int replayMode;
 
     public int totalQueuedTasks;
     public Object output;
 
-    public ApiaryTaskStash(String service, long execId, long callerId, long functionID, boolean isReplay, ZFrame replyAddr, long senderTimestampNano) {
+    public ApiaryTaskStash(String service, long execId, long callerId, long functionID, int replayMode, ZFrame replyAddr, long senderTimestampNano) {
         this.service = service;
         this.execId = execId;
         this.callerId = callerId;
         this.functionID = functionID;
-        this.isReplay = isReplay;
+        this.replayMode = replayMode;
         this.replyAddr = replyAddr;
         this.senderTimestampNano = senderTimestampNano;
         functionIDToValue = new ConcurrentHashMap<>();

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -281,9 +281,10 @@ public class ApiaryWorker {
 
                 if (ApiaryConfig.recordInput &&
                         (replayMode == ApiaryConfig.ReplayMode.NOT_REPLAY.getValue()) &&
-                        (callerID == 0L) && (functionID == 0L) &&
+                        (callerID == 0L) && (execID != 0L) &&
                         (workerContext.provBuff != null)) {
                     // Log function input if recordInput is set to true, during initial execution, and if this is the first function of the entire workflow.
+                    // ExecID = 0l means the initial service function, ignore.
                     workerContext.provBuff.addEntry(ApiaryConfig.tableRecordedInputs, execID, req.toByteArray());
                 }
                 executeFunction(req.getName(), req.getService(), execID, callerID, functionID,

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -303,7 +303,7 @@ public class ApiaryWorker {
             String[] resNames = historyRs.getString(ProvenanceBuffer.PROV_PROCEDURENAME).split("\\.");
             String resName = resNames[resNames.length - 1]; // Extract the actual function name.
             logger.info("Retro-executing txid {}, execid {}, funcid {}, name {}", resTxId, resExecId, resFuncId, resName);
-            if (resExecId != origExecId) {
+            if ((resExecId != origExecId) && (resFuncId == 0l)) {
                 // Read the input for this execution ID.
                 if (inputRs.next()) {
                     origExecId = inputRs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -284,8 +284,10 @@ public class ApiaryWorker {
                 long execID = req.getExecutionId();
                 int replayMode = req.getReplayMode();
                 Object[] arguments = new Object[byteArguments.size()];
+                List<Integer> argSizes = new ArrayList<>();
                 for (int i = 0; i < arguments.length; i++) {
                     byte[] byteArray = byteArguments.get(i).toByteArray();
+                    argSizes.add(byteArray.length);
                     if (argumentTypes.get(i) == stringType) {
                         arguments[i] = new String(byteArray);
                     } else if (argumentTypes.get(i) == intType) {
@@ -302,7 +304,7 @@ public class ApiaryWorker {
                         (callerID == 0L) && (functionID == 0L) &&
                         (workerContext.provBuff != null)) {
                     // Log function input if recordInput is set to true, during initial execution, and if this is the first function of the entire workflow.
-                    workerContext.provBuff.addEntry(ApiaryConfig.tableRecordedInputs, execID, argumentTypes, byteArguments);
+                    workerContext.provBuff.addEntry(ApiaryConfig.tableRecordedInputs, execID, argumentTypes, argSizes, byteArguments);
                 }
                 executeFunction(req.getName(), req.getService(), execID, callerID, functionID,
                         replayMode, address, req.getSenderTimestampNano(), arguments);

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -263,14 +263,14 @@ public class ApiaryWorker {
         String provQuery = String.format("SELECT * FROM %s WHERE %s >= %d AND %s=0 ORDER BY %s;", ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_EXECUTIONID, execID,
                 ProvenanceBuffer.PROV_ISREPLAY, ProvenanceBuffer.PROV_EXECUTIONID);
         Statement stmt = conn.createStatement();
-        ResultSet rs = stmt.executeQuery(provQuery);
+        ResultSet historyRs = stmt.executeQuery(provQuery);
 
         // Re-execute one by one.
-        while (rs.next()) {
-            long resTxId = rs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
-            long resExecId = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
-            long resFuncId = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
-            String resName = rs.getString(ProvenanceBuffer.PROV_PROCEDURENAME);
+        while (historyRs.next()) {
+            long resTxId = historyRs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
+            long resExecId = historyRs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
+            long resFuncId = historyRs.getLong(ProvenanceBuffer.PROV_FUNCID);
+            String resName = historyRs.getString(ProvenanceBuffer.PROV_PROCEDURENAME);
             logger.info("Re-executing txid {}, execid {}, funcid {}, name {}", resTxId, resExecId, resFuncId, resName);
         }
 
@@ -282,7 +282,7 @@ public class ApiaryWorker {
 
         while (inputRs.next()) {
             long resExecId = inputRs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
-            byte[] recordInput = rs.getBytes(ProvenanceBuffer.PROV_REQ_BYTES);
+            byte[] recordInput = inputRs.getBytes(ProvenanceBuffer.PROV_REQ_BYTES);
             ExecuteFunctionRequest req = ExecuteFunctionRequest.parseFrom(recordInput);
             Object[] arguments = Utilities.getArgumentsFromRequest(req);
             logger.info("Original arguments execid {}, inputs {}", resExecId, arguments);

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -256,14 +256,14 @@ public class ApiaryWorker {
     }
 
     private class RequestRunnable implements Runnable, Comparable<RequestRunnable> {
-        private ExecuteFunctionRequest req;
+        private final ExecuteFunctionRequest req;
         private final ZFrame address;
         public long priority;
 
         public RequestRunnable(ZFrame address, ExecuteFunctionRequest req) {
             this.address = address;
+            this.req = req;
             try {
-                this.req = req;
                 long runtime = functionAverageRuntimesNs.getOrDefault(req.getName(), new AtomicDouble(defaultTimeNs)).longValue();
                 this.priority = scheduler.getPriority(req.getService(), runtime);
             } catch (AssertionError | Exception e) {
@@ -304,7 +304,7 @@ public class ApiaryWorker {
                         (callerID == 0L) && (functionID == 0L) &&
                         (workerContext.provBuff != null)) {
                     // Log function input if recordInput is set to true, during initial execution, and if this is the first function of the entire workflow.
-                    workerContext.provBuff.addEntry(ApiaryConfig.tableRecordedInputs, execID, argumentTypes, argSizes, byteArguments);
+                    workerContext.provBuff.addEntry(ApiaryConfig.tableRecordedInputs, execID, req);
                 }
                 executeFunction(req.getName(), req.getService(), execID, callerID, functionID,
                         replayMode, address, req.getSenderTimestampNano(), arguments);

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -260,11 +260,17 @@ public class ApiaryWorker {
         Connection conn = workerContext.provBuff.conn.get();
 
         // Find previous execution history.
-        String provQuery = String.format("SELECT * FROM %s WHERE %s >= %d ORDER BY %s;", ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_EXECUTIONID, execID, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
+        String provQuery = String.format("SELECT * FROM %s WHERE %s >= %d AND %s==0 ORDER BY %s;", ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_EXECUTIONID, execID,
+                ProvenanceBuffer.PROV_ISREPLAY, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
         Statement stmt = conn.createStatement();
         ResultSet rs = stmt.executeQuery(provQuery);
+
         while (rs.next()) {
-            logger.info(rs.toString());
+            long resTxId = rs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
+            long resExecId = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
+            long resFuncId = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
+            String resName = rs.getString(ProvenanceBuffer.PROV_PROCEDURENAME);
+            logger.info("txid {}, execid {}, funcid {}, name {}", resTxId, resExecId, resFuncId, resName);
         }
 
         ExecuteFunctionReply.Builder b = Utilities.constructReply(0l, 0l, senderTimestampNano, 123);

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -317,9 +317,11 @@ public class ApiaryWorker {
 
             FunctionOutput fo = null;
             if (resFuncId == 0l) {
-                 fo = callFunctionInternal(resName, "retroReplay", resExecId, resFuncId, replayMode, origInputs);
+                // This is the first function of a request.
+                fo = callFunctionInternal(resName, "retroReplay", resExecId, resFuncId, replayMode, origInputs);
                 assert (fo != null);
                 output = fo.output;
+                execFuncIdToValue.putIfAbsent(resExecId, new HashMap<>());
             } else {
                 // Find the task in the stash. Make sure that all futures have been resolved.
                 Task currTask = pendingTasks.get(resExecId).get(resFuncId);
@@ -342,6 +344,8 @@ public class ApiaryWorker {
                     execFuncIdToValue.remove(resExecId);
                 }
             }
+            // Store output value.
+            execFuncIdToValue.get(resExecId).putIfAbsent(resFuncId, output);
             // Queue all of its async tasks to the pending map.
             for (Task t : fo.queuedTasks) {
                 pendingTasks.putIfAbsent(resExecId, new HashMap<>());

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -287,7 +287,8 @@ public class ApiaryWorker {
             long resTxId = historyRs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
             long resExecId = historyRs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
             long resFuncId = historyRs.getLong(ProvenanceBuffer.PROV_FUNCID);
-            String resName = historyRs.getString(ProvenanceBuffer.PROV_PROCEDURENAME).split(".")[-1];
+            String[] resNames = historyRs.getString(ProvenanceBuffer.PROV_PROCEDURENAME).split("\\.");
+            String resName = resNames[resNames.length - 1];
             logger.info("Re-executing txid {}, execid {}, funcid {}, name {}", resTxId, resExecId, resFuncId, resName);
             if (inputRs.next()) {
                 // Get input.

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -304,7 +304,7 @@ public class ApiaryWorker {
                         (callerID == 0L) && (functionID == 0L) &&
                         (workerContext.provBuff != null)) {
                     // Log function input if recordInput is set to true, during initial execution, and if this is the first function of the entire workflow.
-                    workerContext.provBuff.addEntry(ApiaryConfig.tableRecordedInputs, execID, req);
+                    workerContext.provBuff.addEntry(ApiaryConfig.tableRecordedInputs, execID, req.toByteArray());
                 }
                 executeFunction(req.getName(), req.getService(), execID, callerID, functionID,
                         replayMode, address, req.getSenderTimestampNano(), arguments);

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -265,6 +265,10 @@ public class ApiaryWorker {
         assert(workerContext.provBuff != null);
         Connection conn = workerContext.provBuff.conn.get();
 
+        // Turn off provenance capture for replay.
+        ApiaryConfig.captureUpdates = false;
+        ApiaryConfig.captureReads = false;
+
         // Find previous execution history.
         String provQuery = String.format("SELECT * FROM %s WHERE %s >= %d AND %s=0 ORDER BY %s;", ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_EXECUTIONID, targetExecID,
                 ProvenanceBuffer.PROV_ISREPLAY, ProvenanceBuffer.PROV_EXECUTIONID);
@@ -293,9 +297,6 @@ public class ApiaryWorker {
         // Re-execute one by one.
         Object output = null;
         while (historyRs.next()) {
-            logger.info(pendingTasks.toString());
-            logger.info(execFuncIdToValue.toString());
-            logger.info(execIdToFinalOutput.toString());
             long resTxId = historyRs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
             long resExecId = historyRs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
             long resFuncId = historyRs.getLong(ProvenanceBuffer.PROV_FUNCID);

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -302,9 +302,7 @@ public class ApiaryWorker {
                         (callerID == 0L) && (functionID == 0L) &&
                         (workerContext.provBuff != null)) {
                     // Log function input if recordInput is set to true, during initial execution, and if this is the first function of the entire workflow.
-                    if (argumentTypes.size() > 0) {
-                        workerContext.provBuff.addEntry(ApiaryConfig.tableRecordedInputs, execID, argumentTypes, byteArguments);
-                    }
+                    workerContext.provBuff.addEntry(ApiaryConfig.tableRecordedInputs, execID, argumentTypes, byteArguments);
                 }
                 executeFunction(req.getName(), req.getService(), execID, callerID, functionID,
                         replayMode, address, req.getSenderTimestampNano(), arguments);

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -290,7 +290,7 @@ public class ApiaryWorker {
 
 
 
-        ExecuteFunctionReply.Builder b = Utilities.constructReply(0l, 0l, senderTimestampNano, List.of(123).toArray());
+        ExecuteFunctionReply.Builder b = Utilities.constructReply(0l, 0l, senderTimestampNano, List.of(123).stream().mapToInt(i -> i).toArray());
         outgoingReplyMsgQueue.add(new OutgoingMsg(replyAddr, b.build().toByteArray()));
     }
 

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -271,7 +271,7 @@ public class ApiaryWorker {
 
         // Find previous execution history.
         String provQuery = String.format("SELECT * FROM %s WHERE %s >= %d AND %s=0 ORDER BY %s;", ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_EXECUTIONID, targetExecID,
-                ProvenanceBuffer.PROV_ISREPLAY, ProvenanceBuffer.PROV_EXECUTIONID);
+                ProvenanceBuffer.PROV_ISREPLAY, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
         Statement stmt = conn.createStatement();
         ResultSet historyRs = stmt.executeQuery(provQuery);
 

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -296,6 +296,14 @@ public class ApiaryWorker {
                         arguments[i] = Utilities.byteArrayToIntArray(byteArray);
                     }
                 }
+
+                if (ApiaryConfig.recordInput &&
+                        (replayMode == ApiaryConfig.ReplayMode.NOT_REPLAY.getValue()) &&
+                        (callerID == 0L) && (functionID == 0L) &&
+                        (workerContext.provBuff != null)) {
+                    // Log function input if recordInput is set to true, during initial execution, and if this is the first function of the entire workflow.
+                    workerContext.provBuff.addEntry(ApiaryConfig.tableRecordedInputs, execID, argumentTypes, byteArguments);
+                }
                 executeFunction(req.getName(), req.getService(), execID, callerID, functionID,
                         replayMode, address, req.getSenderTimestampNano(), arguments);
             } catch (AssertionError | Exception e) {

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -300,11 +300,11 @@ public class ApiaryWorker {
                 execIdFuncIdArgs.putIfAbsent(resExecId2, arguments);
             }
 
-            Object[] input;
+            Object[] originalInput;
             if (resFuncId == 0l) {
                 // Retrieve input from the cache.
-                input = execIdFuncIdArgs.get(resExecId);
-                FunctionOutput o = callFunctionInternal(resName, "retroReplay", execID, resFuncId, replayMode, input);
+                originalInput = execIdFuncIdArgs.get(resExecId);
+                FunctionOutput o = callFunctionInternal(resName, "retroReplay", resExecId, resFuncId, replayMode, originalInput);
                 output = o.output;
             } else {
                 // TODO: implement.

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -302,7 +302,9 @@ public class ApiaryWorker {
                         (callerID == 0L) && (functionID == 0L) &&
                         (workerContext.provBuff != null)) {
                     // Log function input if recordInput is set to true, during initial execution, and if this is the first function of the entire workflow.
-                    workerContext.provBuff.addEntry(ApiaryConfig.tableRecordedInputs, execID, argumentTypes, byteArguments);
+                    if (argumentTypes.size() > 0) {
+                        workerContext.provBuff.addEntry(ApiaryConfig.tableRecordedInputs, execID, argumentTypes, byteArguments);
+                    }
                 }
                 executeFunction(req.getName(), req.getService(), execID, callerID, functionID,
                         replayMode, address, req.getSenderTimestampNano(), arguments);

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -295,6 +295,7 @@ public class ApiaryWorker {
         while (historyRs.next()) {
             logger.info(pendingTasks.toString());
             logger.info(execFuncIdToValue.toString());
+            logger.info(execIdToFinalOutput.toString());
             long resTxId = historyRs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
             long resExecId = historyRs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
             long resFuncId = historyRs.getLong(ProvenanceBuffer.PROV_FUNCID);
@@ -367,8 +368,9 @@ public class ApiaryWorker {
                     execIdToFinalOutput.put(resExecId, resFo);
                     output = resFo;
                 }
-                // Clean up the FuncID to Value map.
+                // Clean up.
                 execFuncIdToValue.remove(resExecId);
+                pendingTasks.remove(resExecId);
             }
         }
 

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -260,7 +260,7 @@ public class ApiaryWorker {
         Connection conn = workerContext.provBuff.conn.get();
 
         // Find previous execution history.
-        String provQuery = String.format("SELECT * FROM %s WHERE %s >= %d AND %s==0 ORDER BY %s;", ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_EXECUTIONID, execID,
+        String provQuery = String.format("SELECT * FROM %s WHERE %s >= %d AND %s=0 ORDER BY %s;", ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_EXECUTIONID, execID,
                 ProvenanceBuffer.PROV_ISREPLAY, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
         Statement stmt = conn.createStatement();
         ResultSet rs = stmt.executeQuery(provQuery);

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -325,9 +325,12 @@ public class ApiaryWorker {
             } else {
                 // Find the task in the stash. Make sure that all futures have been resolved.
                 Task currTask = pendingTasks.get(resExecId).get(resFuncId);
+                assert (currTask != null);
+                logger.info(pendingTasks.toString());
 
                 // Resolve input for this task. Must success.
                 Map<Long, Object> currFuncIdToValue = execFuncIdToValue.get(resExecId);
+                logger.info(execFuncIdToValue.toString());
                 if (!currTask.dereferenceFutures(currFuncIdToValue)) {
                     logger.error("Failed to dereference input for execId {}, funcId {}. Aborted", resExecId, resFuncId);
                     throw new RuntimeException("Retro replay failed to dereference input.");
@@ -349,10 +352,10 @@ public class ApiaryWorker {
             // Queue all of its async tasks to the pending map.
             for (Task t : fo.queuedTasks) {
                 pendingTasks.putIfAbsent(resExecId, new HashMap<>());
-                if (pendingTasks.get(resExecId).containsKey(resFuncId)) {
-                    logger.error("ExecID {} funcID {} has duplicated outputs!", resExecId, resFuncId);
+                if (pendingTasks.get(resExecId).containsKey(t.functionID)) {
+                    logger.error("ExecID {} funcID {} has duplicated outputs!", resExecId, t.functionID);
                 }
-                pendingTasks.get(resExecId).putIfAbsent(resFuncId, t);
+                pendingTasks.get(resExecId).putIfAbsent(t.functionID, t);
             }
         }
 

--- a/src/main/proto/worker.proto
+++ b/src/main/proto/worker.proto
@@ -19,7 +19,7 @@ message ExecuteFunctionRequest {
   int64 senderTimestampNano = 6;
   string service = 7;
   int64 executionId = 8;  // Unique global IDs for an entire workflow.
-  bool isReplay = 9;  // false: not replay, true: isReplay.
+  int32 replayMode = 9;  // 0: not replay, 1: replay a single request, 2: replay a request and everything after.
 }
 
 message ExecuteFunctionReply {

--- a/src/test/java/org/dbos/apiary/PostgresTests.java
+++ b/src/test/java/org/dbos/apiary/PostgresTests.java
@@ -46,6 +46,7 @@ public class PostgresTests {
         try {
             PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, "postgres", "dbos");
             conn.dropTable(ApiaryConfig.tableFuncInvocations);
+            conn.dropTable(ApiaryConfig.tableRecordedInputs);
             conn.dropTable("KVTable");
             conn.createTable("KVTable", "KVKey integer PRIMARY KEY NOT NULL, KVValue integer NOT NULL");
             conn.dropTable("RetwisPosts");

--- a/src/test/java/org/dbos/apiary/PostgresTests.java
+++ b/src/test/java/org/dbos/apiary/PostgresTests.java
@@ -45,7 +45,7 @@ public class PostgresTests {
     public void resetTables() {
         try {
             PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, "postgres", "dbos");
-            conn.dropTable(ProvenanceBuffer.PROV_FuncInvocations);
+            conn.dropTable(ApiaryConfig.tableFuncInvocations);
             conn.dropTable("KVTable");
             conn.createTable("KVTable", "KVKey integer PRIMARY KEY NOT NULL, KVValue integer NOT NULL");
             conn.dropTable("RetwisPosts");

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -213,6 +213,8 @@ public class ProvenanceTests {
         // Retroactively execute all.
         res = client.retroReplay(resExecId3).getInt();
         assertEquals(123, res);
+        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
+
     }
 
     @Test

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -187,6 +187,27 @@ public class ProvenanceTests {
         assertEquals(2, arguments.length);
         assertEquals(123, (int) arguments[0]);
         assertEquals(555, (int) arguments[1]);
+
+        rs.next();
+        recordExecid = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
+        recordInput = rs.getBytes(ProvenanceBuffer.PROV_REQ_BYTES);
+        req = ExecuteFunctionRequest.parseFrom(recordInput);
+        arguments = Utilities.getArgumentsFromRequest(req);
+        assertEquals(resExecId2, recordExecid);
+        assertEquals(resExecId2, req.getExecutionId());
+        assertEquals(2, arguments.length);
+        assertEquals(123, (int) arguments[0]);
+        assertEquals(555, (int) arguments[1]);
+
+        rs.next();
+        recordExecid = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
+        recordInput = rs.getBytes(ProvenanceBuffer.PROV_REQ_BYTES);
+        req = ExecuteFunctionRequest.parseFrom(recordInput);
+        arguments = Utilities.getArgumentsFromRequest(req);
+        assertEquals(resExecId3, recordExecid);
+        assertEquals(resExecId3, req.getExecutionId());
+        assertEquals(1, arguments.length);
+        assertEquals(555, (int) arguments[0]);
     }
 
     @Test

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -208,6 +208,11 @@ public class ProvenanceTests {
         assertEquals(resExecId4, req.getExecutionId());
         assertEquals(1, arguments.length);
         assertEquals(555, (int) arguments[0]);
+        rs.close();
+
+        // Retroactively execute all.
+        res = client.retroReplay(resExecId3).getInt();
+        assertEquals(123, res);
     }
 
     @Test

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -1,8 +1,6 @@
 package org.dbos.apiary;
 
-import com.google.protobuf.Api;
 import com.google.protobuf.InvalidProtocolBufferException;
-import jdk.jshell.execution.Util;
 import org.dbos.apiary.client.ApiaryWorkerClient;
 import org.dbos.apiary.function.ProvenanceBuffer;
 import org.dbos.apiary.postgres.PostgresConnection;
@@ -211,7 +209,8 @@ public class ProvenanceTests {
         rs.close();
 
         // Retroactively execute all.
-        // TODO: reset database and re-execute.
+        // Reset the database and re-execute.
+        conn.truncateTable("ForumSubscription", false);
         resList = client.retroReplay(resExecId).getIntArray();
         assertEquals(1, resList.length);
         assertEquals(123, resList[0]);

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -193,8 +193,8 @@ public class ProvenanceTests {
         recordInput = rs.getBytes(ProvenanceBuffer.PROV_REQ_BYTES);
         req = ExecuteFunctionRequest.parseFrom(recordInput);
         arguments = Utilities.getArgumentsFromRequest(req);
-        assertEquals(resExecId2, recordExecid);
-        assertEquals(resExecId2, req.getExecutionId());
+        assertEquals(resExecId3, recordExecid);
+        assertEquals(resExecId3, req.getExecutionId());
         assertEquals(2, arguments.length);
         assertEquals(123, (int) arguments[0]);
         assertEquals(555, (int) arguments[1]);
@@ -204,8 +204,8 @@ public class ProvenanceTests {
         recordInput = rs.getBytes(ProvenanceBuffer.PROV_REQ_BYTES);
         req = ExecuteFunctionRequest.parseFrom(recordInput);
         arguments = Utilities.getArgumentsFromRequest(req);
-        assertEquals(resExecId3, recordExecid);
-        assertEquals(resExecId3, req.getExecutionId());
+        assertEquals(resExecId4, recordExecid);
+        assertEquals(resExecId4, req.getExecutionId());
         assertEquals(1, arguments.length);
         assertEquals(555, (int) arguments[0]);
     }

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -212,7 +212,7 @@ public class ProvenanceTests {
 
         // Retroactively execute all.
         // TODO: reset database and re-execute.
-        resList = client.retroReplay(resExecId3).getIntArray();
+        resList = client.retroReplay(resExecId).getIntArray();
         assertEquals(1, resList.length);
         assertEquals(123, resList[0]);
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -37,6 +37,7 @@ public class ProvenanceTests {
     @BeforeAll
     public static void testConnection() {
         assumeTrue(TestUtils.testPostgresConnection());
+        ApiaryConfig.recordInput = true;
     }
 
     @BeforeEach

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -211,6 +211,7 @@ public class ProvenanceTests {
         rs.close();
 
         // Retroactively execute all.
+        // TODO: reset database and re-execute.
         resList = client.retroReplay(resExecId3).getIntArray();
         assertEquals(1, resList.length);
         assertEquals(123, resList[0]);

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -1,5 +1,6 @@
 package org.dbos.apiary;
 
+import com.google.protobuf.Api;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.dbos.apiary.client.ApiaryWorkerClient;
 import org.dbos.apiary.function.ProvenanceBuffer;
@@ -42,9 +43,10 @@ public class ProvenanceTests {
     public void resetTables() {
         try {
             PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, "postgres", "dbos");
-            conn.dropTable(ProvenanceBuffer.PROV_FuncInvocations);
+            conn.dropTable(ApiaryConfig.tableFuncInvocations);
             conn.dropTable(ProvenanceBuffer.PROV_ApiaryMetadata);
             conn.dropTable(ProvenanceBuffer.PROV_QueryMetadata);
+            conn.dropTable(ApiaryConfig.tableRecordedInputs);
             conn.dropTable("KVTable");
             conn.createTable("KVTable", "KVKey integer PRIMARY KEY NOT NULL, KVValue integer NOT NULL");
             conn.dropTable("KVTableTwo");
@@ -101,7 +103,7 @@ public class ProvenanceTests {
         Connection provConn = provBuff.conn.get();
         Statement stmt = provConn.createStatement();
 
-        String table = ProvenanceBuffer.PROV_FuncInvocations;
+        String table = ApiaryConfig.tableFuncInvocations;
         ResultSet rs = stmt.executeQuery(String.format("SELECT * FROM %s ORDER BY %s ASC;", table, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID));
         rs.next();
         long resExecId = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
@@ -164,7 +166,7 @@ public class ProvenanceTests {
     public void testProvenanceBuffer() throws InterruptedException, ClassNotFoundException, SQLException {
         logger.info("testProvenanceBuffer");
         ProvenanceBuffer buf = new ProvenanceBuffer(ApiaryConfig.postgres, "localhost");
-        String table = ProvenanceBuffer.PROV_FuncInvocations;
+        String table = ApiaryConfig.tableFuncInvocations;
 
         // Wait until previous exporter finished.
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
@@ -256,7 +258,7 @@ public class ProvenanceTests {
 
         // Check provenance tables.
         // Check function invocation table.
-        String table = ProvenanceBuffer.PROV_FuncInvocations;
+        String table = ApiaryConfig.tableFuncInvocations;
         ResultSet rs = stmt.executeQuery(String.format("SELECT * FROM %s ORDER BY %s DESC;", table, ProvenanceBuffer.PROV_APIARY_TIMESTAMP));
         rs.next();
         long txid1 = rs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -48,6 +48,8 @@ public class ProvenanceTests {
     @BeforeEach
     public void resetTables() {
         try {
+            ApiaryConfig.captureReads = true;
+            ApiaryConfig.captureUpdates = true;
             PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, "postgres", "dbos");
             conn.dropTable(ApiaryConfig.tableFuncInvocations);
             conn.dropTable(ProvenanceBuffer.PROV_ApiaryMetadata);

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -211,8 +211,9 @@ public class ProvenanceTests {
         rs.close();
 
         // Retroactively execute all.
-        res = client.retroReplay(resExecId3).getInt();
-        assertEquals(123, res);
+        resList = client.retroReplay(resExecId3).getIntArray();
+        assertEquals(1, resList.length);
+        assertEquals(123, resList[0]);
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
 
     }


### PR DESCRIPTION
This PR implements `retroReplay` -- replay an execution and everything after it, using the original transaction log for the execution order. In order to implement this feature, I made several changes:

- Changed `isReplay` to `replayMode`. 0: not a replay, 1: replay a single execution using the provenance log, 2: replay an execution and everything after.
- Added an option to log requests. We only need to log the initial client input of each workflow. It uses the provenance buffer so it should not impact performance.
- The Apiary worker uses a single thread to do retroReplay and returns the result once everything is finished. RetroReplay does not generate more TCP requests to the worker.
- Added tests to make sure that we can faithfully follow the original execution order, especially if two requests are interleaving.

Now we can reset the database and re-execute from any point in the past. Will add more optimizations on selective replay in future PRs.