### PR TITLE
Retro benchmark

### DIFF
--- a/src/main/java/org/dbos/apiary/benchmarks/BenchmarkingExecutable.java
+++ b/src/main/java/org/dbos/apiary/benchmarks/BenchmarkingExecutable.java
@@ -28,6 +28,8 @@ public class BenchmarkingExecutable {
         options.addOption("notxn", false, "Disable XDST transaction.");
         options.addOption("skipLoad", false, "Skip data loading.");
         options.addOption("noProv", false, "Disable provenance tracing.");
+        options.addOption("execId", true, "Target execution ID for retro-replay.");
+        options.addOption("retroMode", true, "Replay mode: 0-not replay, 1-single replay execID, 2-replay all after execID.");
 
         CommandLineParser parser = new DefaultParser();
         CommandLine cmd = parser.parse(options, args);
@@ -129,7 +131,15 @@ public class BenchmarkingExecutable {
             int percentageRead = cmd.hasOption("p1") ? Integer.parseInt(cmd.getOptionValue("p1")) : 100;
             int percentageWrite = cmd.hasOption("p2") ? Integer.parseInt(cmd.getOptionValue("p2")) : 100;
             logger.info("Retroactive Benchmark: read {}%, write {}%", percentageRead, percentageWrite);
-            RetroBenchmark.benchmark(mainHostAddr, interval, duration, percentageRead, percentageWrite, skipLoadData);
+            int replayMode = 0;
+            long execId = 0l;
+            if (cmd.hasOption("retroMode")) {
+                replayMode = Integer.parseInt(cmd.getOptionValue("retroMode"));
+                if (replayMode > 0) {
+                    execId = Long.parseLong(cmd.getOptionValue("execId"));
+                }
+            }
+            RetroBenchmark.benchmark(mainHostAddr, interval, duration, percentageRead, percentageWrite, skipLoadData, replayMode, execId);
         }
     }
 }

--- a/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
+++ b/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
@@ -105,7 +105,6 @@ public class RetroBenchmark {
         if (replayMode > 0) {
             long startTime = System.currentTimeMillis();
             replayExec(replayMode, targetExecId);
-            apiaryWorker.shutdown();
             long elapsedTime = System.currentTimeMillis() - startTime;
             int[] resList = client.get().executeFunction("PostgresFetchSubscribers", initialForumId).getIntArray();
             if (resList.length > 1) {
@@ -113,6 +112,7 @@ public class RetroBenchmark {
             } else {
                 logger.info("Replay found no duplications.");
             }
+            apiaryWorker.shutdown();
             logger.info("Replay mode {}, execution time: {} ms", replayMode, elapsedTime);
             return;
         }

--- a/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
+++ b/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
@@ -223,6 +223,7 @@ public class RetroBenchmark {
             pgConn.dropTable(ApiaryConfig.tableFuncInvocations);
             pgConn.dropTable(ProvenanceBuffer.PROV_ApiaryMetadata);
             pgConn.dropTable(ProvenanceBuffer.PROV_QueryMetadata);
+            pgConn.dropTable(ApiaryConfig.tableRecordedInputs);
         } catch (Exception e) {
             e.printStackTrace();
             logger.info("Failed to connect to Postgres.");

--- a/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
+++ b/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
@@ -63,6 +63,8 @@ public class RetroBenchmark {
 
     public static void benchmark(String dbAddr, Integer interval, Integer duration, int percentageRead, int percentageWrite, boolean skipLoad, int replayMode, long targetExecId) throws SQLException, InterruptedException, ExecutionException, InvalidProtocolBufferException {
 
+        ApiaryConfig.isolationLevel = ApiaryConfig.SERIALIZABLE;
+
         if (replayMode == ApiaryConfig.ReplayMode.NOT_REPLAY.getValue()) {
             ApiaryConfig.recordInput = true;
             if (!skipLoad) {

--- a/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
+++ b/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
@@ -91,7 +91,7 @@ public class RetroBenchmark {
         }
         apiaryWorker.registerConnection(ApiaryConfig.postgres, pgConn);
 
-        if (replayMode == 0) {
+        if (replayMode != ApiaryConfig.ReplayMode.ALL.getValue()) {
             // The buggy version.
             apiaryWorker.registerFunction("PostgresIsSubscribed", ApiaryConfig.postgres, PostgresIsSubscribed::new);
             apiaryWorker.registerFunction("PostgresForumSubscribe", ApiaryConfig.postgres, PostgresForumSubscribe::new);

--- a/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
+++ b/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
@@ -71,7 +71,7 @@ public class RetroBenchmark {
                 // Only reset tables if we do initial runs.
                 resetAllTables(dbAddr);
             }
-        } else {
+        } else if (replayMode == ApiaryConfig.ReplayMode.ALL.getValue()){
             ApiaryConfig.recordInput = false;
             // TODO: a better way to restore the database.
             resetAppTables(dbAddr);

--- a/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
+++ b/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
@@ -107,6 +107,12 @@ public class RetroBenchmark {
             replayExec(replayMode, targetExecId);
             apiaryWorker.shutdown();
             long elapsedTime = System.currentTimeMillis() - startTime;
+            int[] resList = client.get().executeFunction("PostgresFetchSubscribers", initialForumId).getIntArray();
+            if (resList.length > 1) {
+                logger.info("Replay found duplications!");
+            } else {
+                logger.info("Replay found no duplications.");
+            }
             logger.info("Replay mode {}, execution time: {} ms", replayMode, elapsedTime);
             return;
         }

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -245,7 +245,7 @@ public class ProvenanceTests {
         ThreadLocal<ApiaryWorkerClient> client = ThreadLocal.withInitial(() -> new ApiaryWorkerClient("localhost"));
 
         // Start a thread pool.
-        ExecutorService threadPool = Executors.newFixedThreadPool(4);
+        ExecutorService threadPool = Executors.newFixedThreadPool(2);
 
         class SubsTask implements Callable<Integer> {
             private final int userId;
@@ -274,6 +274,9 @@ public class ProvenanceTests {
 
         // Push two concurrent tasks.
         List<SubsTask> tasks = new ArrayList<>();
+        tasks.add(new SubsTask(userId, forumId));
+        tasks.add(new SubsTask(userId, forumId));
+        // Then another two tasks. Should not affect the result.
         tasks.add(new SubsTask(userId, forumId));
         tasks.add(new SubsTask(userId, forumId));
         List<Future<Integer>> futures = threadPool.invokeAll(tasks);


### PR DESCRIPTION
This PR adds duplicated entries at the very beginning. So retro replay can always restart from a clean table.
Also fixed a bug in the replay worker: the execution ID is not monotonically increasing. We need to find the corresponding transaction ID and use that to look up the input.

It can benchmark different replay modes: `single` mode will only replay one request using the provenance log, while `all` mode will replay everything. Will add more modes in the future.