### PR TITLE
[Debugger] WordPress example

### DIFF
--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -238,7 +238,7 @@ public class PostgresConnection implements ApiaryConnection {
                                 ex.printStackTrace();
                             }
                         } else {
-                            logger.info("Unrecoverable Postgres error: {} {}", p.getMessage(), p.getSQLState());
+                            logger.info("Unrecoverable PSQLException error: {}, SQLState: {}", p.getMessage(), p.getSQLState());
                         }
                     }
                 }

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -238,8 +238,20 @@ public class PostgresConnection implements ApiaryConnection {
                                 ex.printStackTrace();
                             }
                         } else {
-                            logger.info("Unrecoverable PSQLException error: {}, SQLState: {}", p.getMessage(), p.getSQLState());
+                            logger.info("Unrecoverable inner PSQLException error: {}, SQLState: {}", p.getMessage(), p.getSQLState());
                         }
+                    }
+                } else if (e instanceof PSQLException) {
+                    PSQLException p = (PSQLException) e;
+                    if (p.getSQLState().equals(PSQLState.SERIALIZATION_FAILURE.getState())) {
+                        try {
+                            rollback(ctxt);
+                            continue;
+                        } catch (SQLException ex) {
+                            ex.printStackTrace();
+                        }
+                    } else {
+                        logger.info("Unrecoverable top-level PSQLException error: {}, SQLState: {}", p.getMessage(), p.getSQLState());
                     }
                 }
                 logger.info("Unrecoverable error in function execution: {}", e.getMessage());

--- a/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
@@ -230,6 +230,8 @@ public class PostgresContext extends ApiaryContext {
             metaData[1] = querySeqNum;
             metaData[2] = pstmt.toString();
             if (!ApiaryConfig.captureReads) {
+                metaData[3] = "N/A";
+                metaData[4] = "N/A";
                 // Only capture metadata.
                 workerContext.provBuff.addEntry(ProvenanceBuffer.PROV_QueryMetadata, metaData);
             } else {

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPAddComment.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPAddComment.java
@@ -8,7 +8,8 @@ import java.sql.SQLException;
 
 public class WPAddComment extends PostgresFunction {
 
-    private static final String checkPost = "SELECT " + WPUtil.WP_POST_ID + " FROM " + WPUtil.WP_POSTS_TABLE + " WHERE " + WPUtil.WP_POST_ID + " = ?;";
+    private static final String checkPost = String.format("SELECT %s, %s FROM %s WHERE %s = ?",
+            WPUtil.WP_POST_STATUS, WPUtil.WP_POST_ID, WPUtil.WP_POSTS_TABLE, WPUtil.WP_POST_ID);
 
     // CommentID, PostID, Comment, Status.
     private static final String addComment = "INSERT INTO " + WPUtil.WP_COMMENTS_TABLE + " VALUES(?, ?, ?, ?)";
@@ -21,8 +22,12 @@ public class WPAddComment extends PostgresFunction {
             // Does not exist.
             return -1;
         }
-        // Otherwise, add a comment.
-        ctxt.executeUpdate(addComment, commentId, postId, content, WPUtil.WP_STATUS_VISIBLE);
+        String postStatus = r.getString(WPUtil.WP_POST_STATUS);
+        if (postStatus.equals(WPUtil.WP_STATUS_VISIBLE)) {
+            ctxt.executeUpdate(addComment, commentId, postId, content, WPUtil.WP_STATUS_VISIBLE);
+        } else {
+            ctxt.executeUpdate(addComment, commentId, postId, content, WPUtil.WP_STATUS_POST_TRASHED);
+        }
         return 0;
     }
 }

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPAddComment.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPAddComment.java
@@ -22,12 +22,8 @@ public class WPAddComment extends PostgresFunction {
             // Does not exist.
             return -1;
         }
-        String postStatus = r.getString(WPUtil.WP_POST_STATUS);
-        if (postStatus.equals(WPUtil.WP_STATUS_VISIBLE)) {
-            ctxt.executeUpdate(addComment, commentId, postId, content, WPUtil.WP_STATUS_VISIBLE);
-        } else {
-            ctxt.executeUpdate(addComment, commentId, postId, content, WPUtil.WP_STATUS_POST_TRASHED);
-        }
+
+        ctxt.executeUpdate(addComment, commentId, postId, content, WPUtil.WP_STATUS_VISIBLE);
         return 0;
     }
 }

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPAddComment.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPAddComment.java
@@ -1,0 +1,28 @@
+package org.dbos.apiary.procedures.postgres.wordpress;
+
+import org.dbos.apiary.postgres.PostgresContext;
+import org.dbos.apiary.postgres.PostgresFunction;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class WPAddComment extends PostgresFunction {
+
+    private static final String checkPost = "SELECT " + WPUtil.WP_POST_ID + " FROM " + WPUtil.WP_POSTS_TABLE + " WHERE " + WPUtil.WP_POST_ID + " = ?;";
+
+    // CommentID, PostID, Comment, Status.
+    private static final String addComment = "INSERT INTO " + WPUtil.WP_COMMENTS_TABLE + " VALUES(?, ?, ?, ?)";
+
+    // Return 0 on success, -1 on failure.
+    public static int runFunction(PostgresContext ctxt, long postId, long commentId, String content) throws SQLException {
+        // Check if the post exists.
+        ResultSet r = ctxt.executeQuery(checkPost, postId);
+        if (!r.next()) {
+            // Does not exist.
+            return -1;
+        }
+        // Otherwise, add a comment.
+        ctxt.executeUpdate(addComment, commentId, postId, content, WPUtil.WP_STATUS_VISIBLE);
+        return 0;
+    }
+}

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPAddComment.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPAddComment.java
@@ -14,7 +14,7 @@ public class WPAddComment extends PostgresFunction {
     private static final String addComment = "INSERT INTO " + WPUtil.WP_COMMENTS_TABLE + " VALUES(?, ?, ?, ?)";
 
     // Return 0 on success, -1 on failure.
-    public static int runFunction(PostgresContext ctxt, long postId, long commentId, String content) throws SQLException {
+    public static int runFunction(PostgresContext ctxt, int postId, int commentId, String content) throws SQLException {
         // Check if the post exists.
         ResultSet r = ctxt.executeQuery(checkPost, postId);
         if (!r.next()) {

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPAddPost.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPAddPost.java
@@ -11,7 +11,7 @@ public class WPAddPost extends PostgresFunction {
     private static final String addPost = "INSERT INTO " + WPUtil.WP_POSTS_TABLE + " VALUES (?, ?, ?)";
 
     // Return 0 on success, -1 on failure.
-    public static int runFunction(PostgresContext ctxt, long postId, String content) throws SQLException {
+    public static int runFunction(PostgresContext ctxt, int postId, String content) throws SQLException {
         ctxt.executeUpdate(addPost, postId, content, WPUtil.WP_STATUS_VISIBLE);
         return 0;
     }

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPAddPost.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPAddPost.java
@@ -1,0 +1,18 @@
+package org.dbos.apiary.procedures.postgres.wordpress;
+
+import org.dbos.apiary.postgres.PostgresContext;
+import org.dbos.apiary.postgres.PostgresFunction;
+
+import java.sql.SQLException;
+
+public class WPAddPost extends PostgresFunction {
+
+    // ID, CONTENT, STATUS
+    private static final String addPost = "INSERT INTO " + WPUtil.WP_POSTS_TABLE + " VALUES (?, ?, ?)";
+
+    // Return 0 on success, -1 on failure.
+    public static int runFunction(PostgresContext ctxt, long postId, String content) throws SQLException {
+        ctxt.executeUpdate(addPost, postId, content, WPUtil.WP_STATUS_VISIBLE);
+        return 0;
+    }
+}

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPCheckCommentStatus.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPCheckCommentStatus.java
@@ -1,0 +1,31 @@
+package org.dbos.apiary.procedures.postgres.wordpress;
+
+import org.dbos.apiary.postgres.PostgresContext;
+import org.dbos.apiary.postgres.PostgresFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WPCheckCommentStatus extends PostgresFunction {
+    private static final Logger logger = LoggerFactory.getLogger(WPCheckCommentStatus.class);
+
+    // Return a list of statuses of all comments of a post.
+    private static final String checkStatus = String.format("SELECT %s, COUNT(*) FROM %s WHERE %s = ? GROUP BY %s",
+            WPUtil.WP_COMMENT_STATUS, WPUtil.WP_COMMENTS_TABLE, WPUtil.WP_POST_ID, WPUtil.WP_COMMENT_STATUS);
+
+    public static String[] runFunction(PostgresContext ctxt, int postId) throws SQLException {
+        List<String> statusList = new ArrayList<>();
+        ResultSet r = ctxt.executeQuery(checkStatus, postId);
+        while (r.next()) {
+            String status = r.getString(WPUtil.WP_COMMENT_STATUS);
+            long cnt = r.getLong(2);
+            logger.info("Post {}, comment status {}, count {}", postId, status, cnt);
+            statusList.add(status);
+        }
+        return statusList.toArray(new String[0]);
+    }
+}

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPGetPostComments.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPGetPostComments.java
@@ -1,0 +1,44 @@
+package org.dbos.apiary.procedures.postgres.wordpress;
+
+import org.dbos.apiary.postgres.PostgresContext;
+import org.dbos.apiary.postgres.PostgresFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WPGetPostComments extends PostgresFunction {
+    private static final Logger logger = LoggerFactory.getLogger(WPGetPostComments.class);
+
+    private static final String getPost = String.format("SELECT %s, %s FROM %s WHERE %s = ?",
+            WPUtil.WP_POST_STATUS, WPUtil.WP_POST_CONTENT, WPUtil.WP_POSTS_TABLE, WPUtil.WP_POST_ID);
+    private static final String getComments = String.format("SELECT %s FROM %s WHERE %s = ? AND %s = %s ORDER BY %s",
+            WPUtil.WP_COMMENT_CONTENT, WPUtil.WP_COMMENTS_TABLE, WPUtil.WP_POST_ID, WPUtil.WP_COMMENT_STATUS, WPUtil.WP_STATUS_VISIBLE, WPUtil.WP_COMMENT_ID);
+
+    public static String[] runFunction(PostgresContext ctxt, long postId) throws SQLException {
+        List<String> resList = new ArrayList<>();
+        ResultSet r = ctxt.executeQuery(getPost, postId);
+        if (!r.next()) {
+            logger.error("Post {} does not exist!", postId);
+            return resList.toArray(new String[0]);
+        }
+        String status = r.getString(WPUtil.WP_POST_STATUS);
+        if (status.equals(WPUtil.WP_STATUS_TRASHED)) {
+            logger.error("Post {} is trashed, not visible!", postId);
+            return resList.toArray(new String[0]);
+        }
+        String content = r.getString(WPUtil.WP_POST_CONTENT);
+        resList.add(content);
+
+        // Get all comments.
+        r = ctxt.executeQuery(getComments, postId);
+        while (r.next()) {
+            resList.add(r.getString(WPUtil.WP_COMMENT_CONTENT));
+        }
+
+        return resList.toArray(new String[0]);
+    }
+}

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPGetPostComments.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPGetPostComments.java
@@ -15,7 +15,7 @@ public class WPGetPostComments extends PostgresFunction {
 
     private static final String getPost = String.format("SELECT %s, %s FROM %s WHERE %s = ?",
             WPUtil.WP_POST_STATUS, WPUtil.WP_POST_CONTENT, WPUtil.WP_POSTS_TABLE, WPUtil.WP_POST_ID);
-    private static final String getComments = String.format("SELECT %s FROM %s WHERE %s = ? AND %s = %s ORDER BY %s",
+    private static final String getComments = String.format("SELECT %s FROM %s WHERE %s = ? AND %s = \'%s\' ORDER BY %s",
             WPUtil.WP_COMMENT_CONTENT, WPUtil.WP_COMMENTS_TABLE, WPUtil.WP_POST_ID, WPUtil.WP_COMMENT_STATUS, WPUtil.WP_STATUS_VISIBLE, WPUtil.WP_COMMENT_ID);
 
     public static String[] runFunction(PostgresContext ctxt, int postId) throws SQLException {

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPGetPostComments.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPGetPostComments.java
@@ -18,7 +18,7 @@ public class WPGetPostComments extends PostgresFunction {
     private static final String getComments = String.format("SELECT %s FROM %s WHERE %s = ? AND %s = %s ORDER BY %s",
             WPUtil.WP_COMMENT_CONTENT, WPUtil.WP_COMMENTS_TABLE, WPUtil.WP_POST_ID, WPUtil.WP_COMMENT_STATUS, WPUtil.WP_STATUS_VISIBLE, WPUtil.WP_COMMENT_ID);
 
-    public static String[] runFunction(PostgresContext ctxt, long postId) throws SQLException {
+    public static String[] runFunction(PostgresContext ctxt, int postId) throws SQLException {
         List<String> resList = new ArrayList<>();
         ResultSet r = ctxt.executeQuery(getPost, postId);
         if (!r.next()) {

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPGetPostComments.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPGetPostComments.java
@@ -15,8 +15,8 @@ public class WPGetPostComments extends PostgresFunction {
 
     private static final String getPost = String.format("SELECT %s, %s FROM %s WHERE %s = ?",
             WPUtil.WP_POST_STATUS, WPUtil.WP_POST_CONTENT, WPUtil.WP_POSTS_TABLE, WPUtil.WP_POST_ID);
-    private static final String getComments = String.format("SELECT %s FROM %s WHERE %s = ? AND %s = \'%s\' ORDER BY %s",
-            WPUtil.WP_COMMENT_CONTENT, WPUtil.WP_COMMENTS_TABLE, WPUtil.WP_POST_ID, WPUtil.WP_COMMENT_STATUS, WPUtil.WP_STATUS_VISIBLE, WPUtil.WP_COMMENT_ID);
+    private static final String getComments = String.format("SELECT %s FROM %s WHERE %s = ? AND %s = ? ORDER BY %s",
+            WPUtil.WP_COMMENT_CONTENT, WPUtil.WP_COMMENTS_TABLE, WPUtil.WP_POST_ID, WPUtil.WP_COMMENT_STATUS, WPUtil.WP_COMMENT_ID);
 
     public static String[] runFunction(PostgresContext ctxt, int postId) throws SQLException {
         List<String> resList = new ArrayList<>();
@@ -34,7 +34,7 @@ public class WPGetPostComments extends PostgresFunction {
         resList.add(content);
 
         // Get all comments.
-        r = ctxt.executeQuery(getComments, postId);
+        r = ctxt.executeQuery(getComments, postId, WPUtil.WP_STATUS_VISIBLE);
         while (r.next()) {
             resList.add(r.getString(WPUtil.WP_COMMENT_CONTENT));
         }

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPTrashComments.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPTrashComments.java
@@ -11,12 +11,6 @@ public class WPTrashComments extends PostgresFunction {
     // Return postId on success.
     public static int runFunction(PostgresContext ctxt, int postId) throws SQLException {
         // Trash all visible comments.
-        // Add delay to increase the chance of race.
-        try {
-            Thread.sleep(5);
-        } catch (InterruptedException e) {
-            // Ignore.
-        }
         ctxt.executeUpdate(trashComments, WPUtil.WP_STATUS_POST_TRASHED, postId, WPUtil.WP_STATUS_VISIBLE);
         return postId;
     }

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPTrashComments.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPTrashComments.java
@@ -1,0 +1,17 @@
+package org.dbos.apiary.procedures.postgres.wordpress;
+
+import org.dbos.apiary.postgres.PostgresContext;
+import org.dbos.apiary.postgres.PostgresFunction;
+
+import java.sql.SQLException;
+
+public class WPTrashComments extends PostgresFunction {
+    private static final String trashComments = String.format("UPDATE %s SET %s = ? WHERE %s = ? AND %s = ?", WPUtil.WP_COMMENTS_TABLE, WPUtil.WP_COMMENT_STATUS, WPUtil.WP_POST_ID, WPUtil.WP_COMMENT_STATUS);
+
+    // Return postId on success.
+    public static int runFunction(PostgresContext ctxt, int postId) throws SQLException {
+        // Trash all visible comments.
+        ctxt.executeUpdate(trashComments, WPUtil.WP_STATUS_POST_TRASHED, postId, WPUtil.WP_STATUS_VISIBLE);
+        return postId;
+    }
+}

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPTrashComments.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPTrashComments.java
@@ -11,6 +11,12 @@ public class WPTrashComments extends PostgresFunction {
     // Return postId on success.
     public static int runFunction(PostgresContext ctxt, int postId) throws SQLException {
         // Trash all visible comments.
+        // Add delay to increase the chance of race.
+        try {
+            Thread.sleep(5);
+        } catch (InterruptedException e) {
+            // Ignore.
+        }
         ctxt.executeUpdate(trashComments, WPUtil.WP_STATUS_POST_TRASHED, postId, WPUtil.WP_STATUS_VISIBLE);
         return postId;
     }

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPTrashPost.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPTrashPost.java
@@ -1,0 +1,61 @@
+package org.dbos.apiary.procedures.postgres.wordpress;
+
+import org.dbos.apiary.postgres.PostgresContext;
+import org.dbos.apiary.postgres.PostgresFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WPTrashPost extends PostgresFunction {
+    private static final Logger logger = LoggerFactory.getLogger(WPTrashPost.class);
+
+    private static final String checkPost = String.format("SELECT %s, %s FROM %s WHERE %s = ?;", WPUtil.WP_POST_ID, WPUtil.WP_POST_STATUS, WPUtil.WP_POSTS_TABLE, WPUtil.WP_POST_ID);
+
+    private static final String trashPost = String.format("UPDATE %s SET %s = ? WHERE %s = ?;", WPUtil.WP_POSTS_TABLE, WPUtil.WP_POST_STATUS, WPUtil.WP_POST_ID);
+
+    private static final String getComments = String.format("SELECT %s FROM %s WHERE %s = ? AND %s = ?;",
+            WPUtil.WP_COMMENT_ID, WPUtil.WP_COMMENTS_TABLE, WPUtil.WP_POST_ID, WPUtil.WP_COMMENT_STATUS);
+
+    // PostID, metaKey, metaValue
+    private static final String storeMeta = String.format("INSERT INTO %s VALUES (?, ?, ?);", WPUtil.WP_POSTMETA_TABLE);
+
+    // Find a post, trash the post, and find all visible comments and record them in the postmeta table, and finally queue a function to trash comments.
+    // Return -1 on error, return 0 on no queued function, return a queued function if it has comments.
+    public static Object runFunction(PostgresContext ctxt, int postId) throws SQLException {
+        ResultSet r = ctxt.executeQuery(checkPost, postId);
+
+        if (!r.next()) {
+            logger.error("Post {} does not exist. Cannot trash it.", postId);
+            return -1;
+        }
+
+        String postStatus = r.getString(WPUtil.WP_POST_STATUS);
+        if (postStatus.equals(WPUtil.WP_STATUS_TRASHED)) {
+            logger.info("Post {} has been trashed. Skipped.", postId);
+            return 0;
+        }
+        // Trash the post.
+        ctxt.executeUpdate(trashPost, WPUtil.WP_STATUS_TRASHED, postId);
+
+        // Get comment IDs.
+        r = ctxt.executeQuery(getComments, postId, WPUtil.WP_STATUS_VISIBLE);
+        List<String> commentIds = new ArrayList<>();
+        while (r.next()) {
+            commentIds.add(String.valueOf(r.getLong(WPUtil.WP_COMMENT_ID)));
+        }
+        if (commentIds.isEmpty()) {
+            logger.info("No comments to this post {}. Skip trash comments.", postId);
+        }
+
+        // Store postmeta.
+        String commentIdStr = String.join(",", commentIds);
+        ctxt.executeUpdate(storeMeta, postId, WPUtil.WP_TRASH_KEY, commentIdStr);
+
+        return ctxt.apiaryQueueFunction("WPTrashComments", postId);
+    }
+
+}

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPUntrashPost.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPUntrashPost.java
@@ -36,7 +36,8 @@ public class WPUntrashPost extends PostgresFunction {
         ctxt.executeUpdate(updateQuery, WPUtil.WP_STATUS_VISIBLE);
 
         // Delete metadata.
-        ctxt.executeUpdate(deleteMeta, postId, WPUtil.WP_TRASH_KEY);
+        // TODO: add it back.
+//        ctxt.executeUpdate(deleteMeta, postId, WPUtil.WP_TRASH_KEY);
         return 0;
     }
 

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPUntrashPost.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPUntrashPost.java
@@ -35,9 +35,8 @@ public class WPUntrashPost extends PostgresFunction {
         String updateQuery = String.format(untrashComments, WPUtil.WP_COMMENTS_TABLE, WPUtil.WP_COMMENT_STATUS, WPUtil.WP_COMMENT_ID, commentIdStr);
         ctxt.executeUpdate(updateQuery, WPUtil.WP_STATUS_VISIBLE);
 
-        // Delete metadata.
-        // TODO: add it back.
-//        ctxt.executeUpdate(deleteMeta, postId, WPUtil.WP_TRASH_KEY);
+        // Clean up metadata.
+        ctxt.executeUpdate(deleteMeta, postId, WPUtil.WP_TRASH_KEY);
         return 0;
     }
 

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPUntrashPost.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPUntrashPost.java
@@ -1,0 +1,43 @@
+package org.dbos.apiary.procedures.postgres.wordpress;
+
+import org.dbos.apiary.postgres.PostgresContext;
+import org.dbos.apiary.postgres.PostgresFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class WPUntrashPost extends PostgresFunction {
+    private static final Logger logger = LoggerFactory.getLogger(WPUntrashPost.class);
+    private static final String getMeta = String.format("SELECT %s FROM %s WHERE %s = ? AND %s = ?", WPUtil.WP_META_VALUE, WPUtil.WP_POSTMETA_TABLE, WPUtil.WP_POST_ID, WPUtil.WP_META_KEY);
+
+    private static final String untrashPost = String.format("UPDATE %s SET %s = ? WHERE %s = ?;", WPUtil.WP_POSTS_TABLE, WPUtil.WP_POST_STATUS, WPUtil.WP_POST_ID);
+
+    // Need to fill in actual comment IDs.
+    private static final String untrashComments = "UPDATE %s SET %s = ? WHERE %s IN (%s)";
+
+    private static final String deleteMeta = String.format("DELETE FROM %s WHERE %s = ? AND %s = ?;", WPUtil.WP_POSTMETA_TABLE, WPUtil.WP_POST_ID, WPUtil.WP_META_KEY);
+
+    // Return 0 on success, -1 on failure.
+    public static int runFunction(PostgresContext ctxt, int postId) throws SQLException {
+        ResultSet r = ctxt.executeQuery(getMeta, postId, WPUtil.WP_TRASH_KEY);
+        if (!r.next()) {
+            logger.error("Cannot find metadata for post {}", postId);
+            return -1;
+        }
+        String commentIdStr = r.getString(WPUtil.WP_META_VALUE);
+
+        // Untrash post.
+        ctxt.executeUpdate(untrashPost, WPUtil.WP_STATUS_VISIBLE, postId);
+
+        // Untrash all comments.
+        String updateQuery = String.format(untrashComments, WPUtil.WP_COMMENTS_TABLE, WPUtil.WP_COMMENT_STATUS, WPUtil.WP_COMMENT_ID, commentIdStr);
+        ctxt.executeUpdate(updateQuery, WPUtil.WP_STATUS_VISIBLE);
+
+        // Delete metadata.
+        ctxt.executeUpdate(deleteMeta, postId, WPUtil.WP_TRASH_KEY);
+        return 0;
+    }
+
+}

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPUtil.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPUtil.java
@@ -29,4 +29,8 @@ public class WPUtil {
             + WP_COMMENT_CONTENT + " VARCHAR(2000) NOT NULL, "
             + WP_COMMENT_STATUS + " VARCHAR(20) NOT NULL";
 
+    // For status.
+    public static final String WP_STATUS_VISIBLE = "visible";
+    public static final String WP_STATUS_TRASHED = "trashed";
+    public static final String WP_STATUS_POST_TRASHED = "post-trashed";
 }

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPUtil.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPUtil.java
@@ -1,0 +1,32 @@
+package org.dbos.apiary.procedures.postgres.wordpress;
+
+public class WPUtil {
+    // For the posts table.
+    public static final String WP_POSTS_TABLE = "WP_POSTS";
+    public static final String WP_POST_ID = "POST_ID";
+    public static final String WP_POST_CONTENT = "POST_CONTENT";
+    public static final String WP_POST_STATUS = "POST_STATUS";
+    public static final String WP_POSTS_SCHEMA = WP_POST_ID + " BIGINT PRIMARY KEY NOT NULL, "
+            + WP_POST_CONTENT + " VARCHAR(2000) NOT NULL, "
+            + WP_POST_STATUS + " VARCHAR(20) NOT NULL";
+
+    // For the post metadata table.
+    public static final String WP_POSTMETA_TABLE = "WP_POSTMETA";
+    public static final String WP_META_KEY = "META_KEY";
+    public static final String WP_META_VALUE = "META_VALUE";
+    public static final String WP_TRASH_KEY = "_wp_trash_meta_comments_";
+    public static final String WP_POSTMETA_SCHEMA = WP_POST_ID + " BIGINT NOT NULL, "
+            + WP_META_KEY + " VARCHAR(255) NOT NULL, "
+            + WP_META_VALUE + " VARCHAR(1000) NOT NULL";
+
+    // For the comments table.
+    public static final String WP_COMMENTS_TABLE = "WP_COMMENTS";
+    public static final String WP_COMMENT_ID = "COMMENT_ID";
+    public static final String WP_COMMENT_CONTENT = "COMMENT_CONTENT";
+    public static final String WP_COMMENT_STATUS = "COMMENT_STATUS";
+    public static final String WP_COMMENTS_SCHEMA = WP_COMMENT_ID + " BIGINT PRIMARY KEY NOT NULL, "
+            + WP_POST_ID + " BIGINT NOT NULL, "
+            + WP_COMMENT_CONTENT + " VARCHAR(2000) NOT NULL, "
+            + WP_COMMENT_STATUS + " VARCHAR(20) NOT NULL";
+
+}

--- a/src/main/java/org/dbos/apiary/utilities/ApiaryConfig.java
+++ b/src/main/java/org/dbos/apiary/utilities/ApiaryConfig.java
@@ -58,5 +58,6 @@ public class ApiaryConfig {
     public static Boolean recordInput = false;  // If true, capture input of the entry function and record in a table.
     public static final String tableRecordedInputs = "RECORDEDINPUTS";
 
-
+    // For fault injection.
+    public static Boolean workerAsyncDelay = false;  // If true, add a few milliseconds of delay between async function invocations.
 }

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -105,15 +105,21 @@ public class ApiaryWorker {
         try {
             garbageCollect = false;
             Thread.sleep(100);
-            garbageCollectorThread.interrupt();
-            garbageCollectorThread.join();
+            if (garbageCollectorThread != null) {
+                garbageCollectorThread.interrupt();
+                garbageCollectorThread.join();
+            }
             reqThreadPool.shutdown();
             reqThreadPool.awaitTermination(10, TimeUnit.SECONDS);
             repThreadPool.shutdown();
             repThreadPool.awaitTermination(10, TimeUnit.SECONDS);
-            serverThread.interrupt();
+            if (serverThread != null) {
+                serverThread.interrupt();
+            }
             zContext.close();
-            serverThread.join();
+            if (serverThread != null) {
+                serverThread.join();
+            }
             if (workerContext.provBuff != null) {
                 workerContext.provBuff.close();
             }

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -164,8 +164,10 @@ public class ApiaryWorker {
                             workerContext.getPrimaryConnection().getPartitionHostMap().get(0)
                             : workerContext.getPrimaryConnection().getHostname(subtask.input);
                     // Push to the outgoing queue.
-                    // TODO: Debug, find a better way to inject delays.
-                    Thread.sleep(5);
+                    if (ApiaryConfig.workerAsyncDelay) {
+                        // Add some delay if we are trying to do fault injection.
+                        Thread.sleep(ThreadLocalRandom.current().nextInt(10));
+                    }
                     byte[] reqBytes = InternalApiaryWorkerClient.serializeExecuteRequest(subtask.funcName, currTask.service, currTask.execId, currTask.replayMode, currCallerID, subtask.functionID, subtask.input);
                     outgoingReqMsgQueue.add(new OutgoingMsg(address, reqBytes));
                 }

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -164,6 +164,8 @@ public class ApiaryWorker {
                             workerContext.getPrimaryConnection().getPartitionHostMap().get(0)
                             : workerContext.getPrimaryConnection().getHostname(subtask.input);
                     // Push to the outgoing queue.
+                    // TODO: Debug, find a better way to inject delays.
+                    Thread.sleep(5);
                     byte[] reqBytes = InternalApiaryWorkerClient.serializeExecuteRequest(subtask.funcName, currTask.service, currTask.execId, currTask.replayMode, currCallerID, subtask.functionID, subtask.input);
                     outgoingReqMsgQueue.add(new OutgoingMsg(address, reqBytes));
                 }

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -100,5 +100,8 @@ public class WordPressTests {
         assertTrue(resList[0].equals("test post"));
         assertTrue(resList[1].equals("test comment to a post."));
         assertTrue(resList[2].equals("second test comment to a post."));
+
+        // Check provenance.
+        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
     }
 }

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -145,7 +145,7 @@ public class WordPressTests {
         ThreadLocal<ApiaryWorkerClient> client = ThreadLocal.withInitial(() -> new ApiaryWorkerClient("localhost"));
 
         // Start a thread pool.
-        ExecutorService threadPool = Executors.newFixedThreadPool(1);
+        ExecutorService threadPool = Executors.newFixedThreadPool(2);
 
         class WpTask implements Callable<Integer> {
             private final int postId;

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -145,7 +145,7 @@ public class WordPressTests {
         ThreadLocal<ApiaryWorkerClient> client = ThreadLocal.withInitial(() -> new ApiaryWorkerClient("localhost"));
 
         // Start a thread pool.
-        ExecutorService threadPool = Executors.newFixedThreadPool(4);
+        ExecutorService threadPool = Executors.newFixedThreadPool(1);
 
         class WpTask implements Callable<Integer> {
             private final int postId;

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -68,7 +68,7 @@ public class WordPressTests {
     @Test
     public void testWPSerialized() throws SQLException {
         logger.info("testWPSerialized");
-        PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, ApiaryConfig.dbosDBName, "dbos");
+        PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, ApiaryConfig.postgres, "dbos");
 
         apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
         apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -184,9 +184,10 @@ public class WordPressTests {
         // Try many times until we find inconsistency.
         int postIds = 0;
         int commentIds = 0;
-        int maxTry = 10;
+        int maxTry = 100;
         int intRes;
         String[] strAryRes;
+        boolean foundInconsistency = false;
         for (int i = 0; i < maxTry; i++) {
             // Add a new post and a comment.
             intRes = client.get().executeFunction("WPAddPost", postIds, "test post " + postIds).getInt();
@@ -219,6 +220,7 @@ public class WordPressTests {
             strAryRes = client.get().executeFunction("WPCheckCommentStatus", postIds).getStringArray();
             if (strAryRes.length > 1) {
                 logger.info("Found inconsistency!");
+                foundInconsistency = true;
                 break;
             }
             postIds++;
@@ -226,6 +228,7 @@ public class WordPressTests {
         }
 
         threadPool.shutdown();
+        assertTrue(foundInconsistency);
         // Check provenance.
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
     }

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -129,6 +129,7 @@ public class WordPressTests {
     public void testWPConcurrent() throws SQLException, InvalidProtocolBufferException, InterruptedException {
         // Try to reproduce the bug where the new comment comes between post trashed and comment trashed. So the new comment would be marked as trashed but cannot be restored afterwards.
         logger.info("testWPConcurrent");
+        ApiaryConfig.workerAsyncDelay = true;
         PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, ApiaryConfig.postgres, "dbos");
 
         apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
@@ -229,6 +230,7 @@ public class WordPressTests {
 
         threadPool.shutdown();
         assertTrue(foundInconsistency);
+        ApiaryConfig.workerAsyncDelay = false;  // Reset flag.
         // Check provenance.
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
     }

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -4,10 +4,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.dbos.apiary.client.ApiaryWorkerClient;
 import org.dbos.apiary.function.ProvenanceBuffer;
 import org.dbos.apiary.postgres.PostgresConnection;
-import org.dbos.apiary.procedures.postgres.wordpress.WPAddComment;
-import org.dbos.apiary.procedures.postgres.wordpress.WPAddPost;
-import org.dbos.apiary.procedures.postgres.wordpress.WPGetPostComments;
-import org.dbos.apiary.procedures.postgres.wordpress.WPUtil;
+import org.dbos.apiary.procedures.postgres.wordpress.*;
 import org.dbos.apiary.utilities.ApiaryConfig;
 import org.dbos.apiary.worker.ApiaryNaiveScheduler;
 import org.dbos.apiary.worker.ApiaryWorker;
@@ -82,6 +79,8 @@ public class WordPressTests {
         apiaryWorker.registerFunction("WPAddPost", ApiaryConfig.postgres, WPAddPost::new);
         apiaryWorker.registerFunction("WPAddComment", ApiaryConfig.postgres, WPAddComment::new);
         apiaryWorker.registerFunction("WPGetPostComments", ApiaryConfig.postgres, WPGetPostComments::new);
+        apiaryWorker.registerFunction("WPTrashPost", ApiaryConfig.postgres, WPTrashPost::new);
+        apiaryWorker.registerFunction("WPTrashComments", ApiaryConfig.postgres, WPTrashComments::new);
         apiaryWorker.startServing();
         ApiaryWorkerClient client = new ApiaryWorkerClient("localhost");
 
@@ -101,6 +100,10 @@ public class WordPressTests {
         assertTrue(resList[1].equals("test comment to a post."));
         assertTrue(resList[2].equals("second test comment to a post."));
 
+        // Trash the post.
+        res = client.executeFunction("WPTrashPost", 123).getInt();
+        assertEquals(123, res);
+        
         // Check provenance.
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
     }

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -197,6 +197,7 @@ public class WordPressTests {
 
             // Launch concurrent tasks.
             Future<Integer> trashResFut = threadPool.submit(new WpTask(postIds, -1, "trashpost"));
+            Thread.sleep(1);
             Future<Integer> commentResFut = threadPool.submit(new WpTask(postIds, commentIds, "test comment to a post " + commentIds));
 
             int trashRes, commentRes;

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -86,16 +86,16 @@ public class WordPressTests {
         ApiaryWorkerClient client = new ApiaryWorkerClient("localhost");
 
         int res;
-        res = client.executeFunction("WPAddComment", 123l, 3450l, "this should not work.").getInt();
+        res = client.executeFunction("WPAddComment", 123, 3450, "this should not work.").getInt();
         assertEquals(-1, res);
-        res = client.executeFunction("WPAddPost", 123l, "test post").getInt();
+        res = client.executeFunction("WPAddPost", 123, "test post").getInt();
         assertEquals(0, res);
-        res = client.executeFunction("WPAddComment", 123l, 3450l, "test comment to a post.").getInt();
+        res = client.executeFunction("WPAddComment", 123, 3450, "test comment to a post.").getInt();
         assertEquals(0, res);
-        res = client.executeFunction("WPAddComment", 123l, 3460l, "second test comment to a post.").getInt();
+        res = client.executeFunction("WPAddComment", 123, 3460, "second test comment to a post.").getInt();
         assertEquals(0, res);
 
-        String[] resList = client.executeFunction("WPGetPostComments", 123l).getStringArray();
+        String[] resList = client.executeFunction("WPGetPostComments", 123).getStringArray();
         assertEquals(3, resList.length);
         assertTrue(resList[0].equals("test post"));
         assertTrue(resList[1].equals("test comment to a post."));

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -1,0 +1,76 @@
+package org.dbos.apiary;
+
+import org.dbos.apiary.function.ProvenanceBuffer;
+import org.dbos.apiary.postgres.PostgresConnection;
+import org.dbos.apiary.procedures.postgres.wordpress.WPUtil;
+import org.dbos.apiary.utilities.ApiaryConfig;
+import org.dbos.apiary.worker.ApiaryNaiveScheduler;
+import org.dbos.apiary.worker.ApiaryWorker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+// To test the bug and fixes of WordPress-11073: https://core.trac.wordpress.org/ticket/11073
+public class WordPressTests {
+    private static final Logger logger = LoggerFactory.getLogger(WordPressTests.class);
+
+    private ApiaryWorker apiaryWorker;
+
+    @BeforeAll
+    public static void testConnection() {
+        assumeTrue(TestUtils.testPostgresConnection());
+        // Set the isolation level to serializable.
+        ApiaryConfig.isolationLevel = ApiaryConfig.SERIALIZABLE;
+
+        // Disable XDB transactions.
+        ApiaryConfig.XDBTransactions = false;
+
+        // Disable read tracking.
+        ApiaryConfig.captureReads = false;
+    }
+
+    @BeforeEach
+    public void resetTables() {
+        try {
+            PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, ApiaryConfig.postgres, "dbos");
+            conn.dropTable(ApiaryConfig.tableFuncInvocations);
+            conn.dropTable(ApiaryConfig.tableRecordedInputs);
+            conn.dropTable(ProvenanceBuffer.PROV_ApiaryMetadata);
+            conn.dropTable(ProvenanceBuffer.PROV_QueryMetadata);
+            conn.dropTable(WPUtil.WP_POSTS_TABLE);
+            conn.createTable(WPUtil.WP_POSTS_TABLE, WPUtil.WP_POSTS_SCHEMA);
+            conn.dropTable(WPUtil.WP_POSTMETA_TABLE);
+            conn.createTable(WPUtil.WP_POSTMETA_TABLE, WPUtil.WP_POSTMETA_SCHEMA);
+            conn.dropTable(WPUtil.WP_COMMENTS_TABLE);
+            conn.createTable(WPUtil.WP_COMMENTS_TABLE, WPUtil.WP_COMMENTS_SCHEMA);
+        } catch (Exception e) {
+            e.printStackTrace();
+            logger.info("Failed to connect to Postgres.");
+            assumeTrue(false);
+        }
+        apiaryWorker = null;
+    }
+
+    @AfterEach
+    public void cleanupWorker() {
+        if (apiaryWorker != null) {
+            apiaryWorker.shutdown();
+        }
+    }
+
+    @Test
+    public void testWPSerialized() throws SQLException {
+        logger.info("testWPSerialized");
+        PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, ApiaryConfig.dbosDBName, "dbos");
+
+        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
+        apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);
+    }
+}

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -197,7 +197,8 @@ public class WordPressTests {
 
             // Launch concurrent tasks.
             Future<Integer> trashResFut = threadPool.submit(new WpTask(postIds, -1, "trashpost"));
-            Thread.sleep(1);
+            // Add arbitrary delay.
+            Thread.sleep(ThreadLocalRandom.current().nextInt(5));
             Future<Integer> commentResFut = threadPool.submit(new WpTask(postIds, commentIds, "test comment to a post " + commentIds));
 
             int trashRes, commentRes;

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -81,6 +81,7 @@ public class WordPressTests {
         apiaryWorker.registerFunction("WPGetPostComments", ApiaryConfig.postgres, WPGetPostComments::new);
         apiaryWorker.registerFunction("WPTrashPost", ApiaryConfig.postgres, WPTrashPost::new);
         apiaryWorker.registerFunction("WPTrashComments", ApiaryConfig.postgres, WPTrashComments::new);
+        apiaryWorker.registerFunction("WPUntrashPost", ApiaryConfig.postgres, WPUntrashPost::new);
         apiaryWorker.startServing();
         ApiaryWorkerClient client = new ApiaryWorkerClient("localhost");
 
@@ -103,7 +104,11 @@ public class WordPressTests {
         // Trash the post.
         res = client.executeFunction("WPTrashPost", 123).getInt();
         assertEquals(123, res);
-        
+
+        // Untrash the post.
+        res = client.executeFunction("WPUntrashPost", 123).getInt();
+        assertEquals(0, res);
+
         // Check provenance.
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
     }

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -73,7 +73,7 @@ public class WordPressTests {
     }
 
     @Test
-    public void testWPSerialized() throws SQLException, InvalidProtocolBufferException {
+    public void testWPSerialized() throws SQLException, InvalidProtocolBufferException, InterruptedException {
         logger.info("testWPSerialized");
         PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, ApiaryConfig.postgres, "dbos");
 

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -224,6 +224,7 @@ public class WordPressTests {
             commentIds++;
         }
 
+        threadPool.shutdown();
         // Check provenance.
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
     }


### PR DESCRIPTION
This PR implements [WordPress-11073](https://core.trac.wordpress.org/ticket/11073), where the bug fix actually introduced a race condition:

While trashing a post and its comments, it contains two steps: first back up comments in a `postmeta` table and then mark all comments as trashed. if a new comment arrives in between these two steps, the new comment would not be recorded in `postmeta` table but would be marked as trashed in the second step.
Then if we need to untrash the post and restore its comments, the code will look up `postmeta` and try to unmark those trashed posts. However, the latest comment will not show up because it is still marked as trashed.

In order to simulate interleaving executions of functions, this PR introduced `workerAsyncDelay` in ApiaryConifg. So it will be easier to reproduce race conditions due to non-transactional workflow executions.

This PR also fixed an error handling bug in `PostgresConnection.java`: the code did not capture or retry serialization failure if the exception occurred during the commit phase. So we have to check if the outermost level exception is `PSQLException` as well.

One issue I also realized is that serializable isolation in Postgres cannot guarantee that the transaction ID order is the same as the actual transaction schedule order! For example, transaction A has a smaller transaction ID than B and A started first. However, the actual schedule could be B -> A. So even if the transaction log shows interleaved transactions, the actual order might not be interleaved at all. This may be just a Postgres issue but could lead to some unexpected outcomes.
