### PR TITLE
Record Function Invocation at Commit and Update WP

### DIFF
--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -41,6 +41,12 @@ public class ProvenanceBuffer {
     public static final String PROV_QUERY_TABLENAMES = "APIARY_QUERY_TABLENAMES";
     public static final String PROV_QUERY_PROJECTION = "APIARY_QUERY_PROJECTION";
     public static final String PROV_REQ_BYTES = "APIARY_REQ_BYTES";
+    public static final String PROV_END_TIMESTAMP = "APIARY_END_TIMESTAMP";
+    // For the status column.
+    public static final String PROV_FUNC_STATUS = "APIARY_FUNC_STATUS";
+    public static final String PROV_STATUS_COMMIT = "commit";
+    public static final String PROV_STATUS_ROLLBACK = "rollback";
+    public static final String PROV_STATUS_ABORT = "abort";
 
     /**
      * Enum class for provenance operations.

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -47,6 +47,7 @@ public class ProvenanceBuffer {
     public static final String PROV_STATUS_COMMIT = "commit";
     public static final String PROV_STATUS_ROLLBACK = "rollback";
     public static final String PROV_STATUS_ABORT = "abort";
+    public static final String PROV_STATUS_EMBEDDED = "embedded";
 
     /**
      * Enum class for provenance operations.

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -6,6 +6,7 @@ import org.dbos.apiary.function.ProvenanceBuffer;
 import org.dbos.apiary.function.TransactionContext;
 import org.dbos.apiary.function.WorkerContext;
 import org.dbos.apiary.utilities.ApiaryConfig;
+import org.dbos.apiary.utilities.Utilities;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.PSQLState;
@@ -83,7 +84,9 @@ public class PostgresConnection implements ApiaryConnection {
                 + ProvenanceBuffer.PROV_FUNCID + " BIGINT NOT NULL, "
                 + ProvenanceBuffer.PROV_ISREPLAY + " SMALLINT NOT NULL, "
                 + ProvenanceBuffer.PROV_SERVICE + " VARCHAR(1024) NOT NULL, "
-                + ProvenanceBuffer.PROV_PROCEDURENAME + " VARCHAR(1024) NOT NULL");
+                + ProvenanceBuffer.PROV_PROCEDURENAME + " VARCHAR(1024) NOT NULL, "
+                + ProvenanceBuffer.PROV_END_TIMESTAMP + " BIGINT, "
+                + ProvenanceBuffer.PROV_FUNC_STATUS + "VARCHAR(20) ");
         createTable(ProvenanceBuffer.PROV_ApiaryMetadata,
                 "Key VARCHAR(1024) NOT NULL, Value Integer, PRIMARY KEY(key)");
         createTable(ProvenanceBuffer.PROV_QueryMetadata,
@@ -192,6 +195,8 @@ public class PostgresConnection implements ApiaryConnection {
         Connection c = connection.get();
         FunctionOutput f = null;
         while (true) {
+            // Record invocation for each try, if we have provenance buffer.
+            long startTime = Utilities.getMicroTimestamp();
             activeTransactionsLock.readLock().lock();
             PostgresContext ctxt = new PostgresContext(c, workerContext, service, execID, functionID, replayMode,
                     new HashSet<>(activeTransactions), new HashSet<>(abortedTransactions));
@@ -217,9 +222,12 @@ public class PostgresConnection implements ApiaryConnection {
                         ctxt.workerContext.getSecondaryConnection(secondary).commit(writtenKeys, ctxt.txc);
                     }
                     activeTransactions.remove(ctxt.txc);
+                    // Record invocation information.
+                    recordTransactionInfo(workerContext, ctxt, startTime, functionName, ProvenanceBuffer.PROV_STATUS_COMMIT);
                     break;
                 } else {
                     rollback(ctxt);
+                    recordTransactionInfo(workerContext, ctxt, startTime, functionName, ProvenanceBuffer.PROV_STATUS_ROLLBACK);
                 }
             } catch (Exception e) {
                 if (e instanceof InvocationTargetException) {
@@ -233,6 +241,7 @@ public class PostgresConnection implements ApiaryConnection {
                         if (p.getSQLState().equals(PSQLState.SERIALIZATION_FAILURE.getState())) {
                             try {
                                 rollback(ctxt);
+                                recordTransactionInfo(workerContext, ctxt, startTime, functionName, ProvenanceBuffer.PROV_STATUS_ROLLBACK);
                                 continue;
                             } catch (SQLException ex) {
                                 ex.printStackTrace();
@@ -246,6 +255,7 @@ public class PostgresConnection implements ApiaryConnection {
                     if (p.getSQLState().equals(PSQLState.SERIALIZATION_FAILURE.getState())) {
                         try {
                             rollback(ctxt);
+                            recordTransactionInfo(workerContext, ctxt, startTime, functionName, ProvenanceBuffer.PROV_STATUS_ROLLBACK);
                             continue;
                         } catch (SQLException ex) {
                             ex.printStackTrace();
@@ -256,9 +266,11 @@ public class PostgresConnection implements ApiaryConnection {
                 }
                 logger.info("Unrecoverable error in function execution: {}", e.getMessage());
                 e.printStackTrace();
+                recordTransactionInfo(workerContext, ctxt, startTime, functionName, ProvenanceBuffer.PROV_STATUS_ABORT);
                 break;
             }
         }
+
         return f;
     }
 
@@ -299,4 +311,12 @@ public class PostgresConnection implements ApiaryConnection {
         return Map.of(0, "localhost");
     }
 
+    private void recordTransactionInfo(WorkerContext workerContext, PostgresContext ctxt, long startTime, String functionName, String status) {
+        if (workerContext.provBuff == null) {
+            return;
+        }
+        // TODO: need a more reliable way to record commit timestamp. Maybe with track_commit_timestamp.
+        long commitTime = Utilities.getMicroTimestamp();
+        workerContext.provBuff.addEntry(ApiaryConfig.tableFuncInvocations, ctxt.txc.txID, startTime, ctxt.execID, ctxt.functionID, (short)ctxt.replayMode, ctxt.service, functionName, commitTime, status);
+    }
 }

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -86,7 +86,7 @@ public class PostgresConnection implements ApiaryConnection {
                 + ProvenanceBuffer.PROV_SERVICE + " VARCHAR(1024) NOT NULL, "
                 + ProvenanceBuffer.PROV_PROCEDURENAME + " VARCHAR(1024) NOT NULL, "
                 + ProvenanceBuffer.PROV_END_TIMESTAMP + " BIGINT, "
-                + ProvenanceBuffer.PROV_FUNC_STATUS + "VARCHAR(20) ");
+                + ProvenanceBuffer.PROV_FUNC_STATUS + " VARCHAR(20) ");
         createTable(ProvenanceBuffer.PROV_ApiaryMetadata,
                 "Key VARCHAR(1024) NOT NULL, Value Integer, PRIMARY KEY(key)");
         createTable(ProvenanceBuffer.PROV_QueryMetadata,

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -312,7 +312,7 @@ public class PostgresConnection implements ApiaryConnection {
     }
 
     private void recordTransactionInfo(WorkerContext workerContext, PostgresContext ctxt, long startTime, String functionName, String status) {
-        if (workerContext.provBuff == null) {
+        if ((workerContext.provBuff == null) || (ctxt.execID == 0)) {
             return;
         }
         // TODO: need a more reliable way to record commit timestamp. Maybe with track_commit_timestamp.

--- a/src/main/java/org/dbos/apiary/postgres/PostgresFunction.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresFunction.java
@@ -15,14 +15,5 @@ public class PostgresFunction implements ApiaryFunction {
 
     @Override
     public void recordInvocation(ApiaryContext ctxt, String funcName) {
-        short isreplay = (short) ctxt.replayMode;
-
-        if (ctxt.workerContext.provBuff == null) {
-            // If no OLAP DB available.
-            return;
-        }
-        long timestamp = Utilities.getMicroTimestamp();
-        long txid = ((PostgresContext) ctxt).txc.txID;
-        ctxt.workerContext.provBuff.addEntry(ApiaryConfig.tableFuncInvocations, txid, timestamp, ctxt.execID, ctxt.functionID, isreplay, ctxt.service, funcName);
     }
 }

--- a/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPAddCommentFixed.java
+++ b/src/main/java/org/dbos/apiary/procedures/postgres/wordpress/WPAddCommentFixed.java
@@ -1,0 +1,40 @@
+package org.dbos.apiary.procedures.postgres.wordpress;
+
+import org.dbos.apiary.postgres.PostgresContext;
+import org.dbos.apiary.postgres.PostgresFunction;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class WPAddCommentFixed extends PostgresFunction {
+    // The bug fix version of WP AddComment.
+    private static final String checkPost = String.format("SELECT %s, %s FROM %s WHERE %s = ?",
+            WPUtil.WP_POST_STATUS, WPUtil.WP_POST_ID, WPUtil.WP_POSTS_TABLE, WPUtil.WP_POST_ID);
+
+    // Check if the post is being trashed.
+    private static final String checkPostmeta = String.format("SELECT %s FROM %s WHERE %s = ? AND %s = ?;", WPUtil.WP_POST_ID, WPUtil.WP_POSTMETA_TABLE, WPUtil.WP_META_KEY, WPUtil.WP_POST_ID);
+
+    // CommentID, PostID, Comment, Status.
+    private static final String addComment = "INSERT INTO " + WPUtil.WP_COMMENTS_TABLE + " VALUES(?, ?, ?, ?)";
+
+    // Return 0 on success, -1 on failure.
+    public static int runFunction(PostgresContext ctxt, int postId, int commentId, String content) throws SQLException {
+        // Check if the post exists.
+        ResultSet r = ctxt.executeQuery(checkPost, postId);
+        if (!r.next()) {
+            // Does not exist.
+            return -1;
+        }
+
+        // Check if the post is being trashed or already trashed. If so, do not add this comment.
+        r = ctxt.executeQuery(checkPostmeta, WPUtil.WP_TRASH_KEY, postId);
+        if (r.next()) {
+            // The post is being trashed or already trashed. Do not add a comment to this post.
+            return -1;
+        }
+
+        // Otherwise, add the comment to the post.
+        ctxt.executeUpdate(addComment, commentId, postId, content, WPUtil.WP_STATUS_VISIBLE);
+        return 0;
+    }
+}

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -280,7 +280,8 @@ public class ApiaryWorker {
         ApiaryConfig.captureUpdates = false;
         ApiaryConfig.captureReads = false;
 
-        // Find previous execution history.
+        // Find previous execution history, only execute later committed transactions.
+        // TODO: maybe re-execute aborted transaction, especially for bug reproduction?
         String provQuery = String.format("SELECT %s FROM %s WHERE %s = %d AND %s=0 AND %s=0;",
                 ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID, ApiaryConfig.tableFuncInvocations,
                 ProvenanceBuffer.PROV_EXECUTIONID, targetExecID, ProvenanceBuffer.PROV_FUNCID,
@@ -295,8 +296,11 @@ public class ApiaryWorker {
             throw new RuntimeException("Cannot find original transactioin!");
         }
         historyRs.close();
-        provQuery = String.format("SELECT * FROM %s WHERE %s >= %d AND %s=0 ORDER BY %s;", ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID, origTxid,
-                ProvenanceBuffer.PROV_ISREPLAY, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
+
+        // Replay based on the commit order.
+        // TODO: This may still cause an issue because transaction/commit order != actual serial order. Replay based on the correct snapshot?
+        provQuery = String.format("SELECT * FROM %s WHERE %s >= %d AND %s=0 AND %s=%s ORDER BY %s;", ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID, origTxid,
+                ProvenanceBuffer.PROV_ISREPLAY,  ProvenanceBuffer.PROV_FUNC_STATUS, ProvenanceBuffer.PROV_STATUS_COMMIT, ProvenanceBuffer.PROV_END_TIMESTAMP);
         historyRs = stmt.executeQuery(provQuery);
 
         // Find previous input of execution ID.
@@ -329,13 +333,13 @@ public class ApiaryWorker {
                 if (origExecId == -1) {
                     // Get the input data.
                     String inputQuery = String.format("SELECT %s, r.%s, %s FROM %s AS r INNER JOIN %s as f ON r.%s = f.%s " +
-                                    "WHERE %s >= %d AND %s = 0 AND %s = 0 ORDER BY %s;",
+                                    "WHERE %s >= %d AND %s = 0 AND %s = 0 AND %s=%s ORDER BY %s;",
                             ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID, ProvenanceBuffer.PROV_EXECUTIONID,
                             ProvenanceBuffer.PROV_REQ_BYTES, ApiaryConfig.tableRecordedInputs,
                             ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_EXECUTIONID,
                             ProvenanceBuffer.PROV_EXECUTIONID, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID,
-                            resTxId, ProvenanceBuffer.PROV_FUNCID, ProvenanceBuffer.PROV_ISREPLAY,
-                            ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID
+                            resTxId, ProvenanceBuffer.PROV_FUNCID, ProvenanceBuffer.PROV_ISREPLAY,  ProvenanceBuffer.PROV_FUNC_STATUS, ProvenanceBuffer.PROV_STATUS_COMMIT,
+                            ProvenanceBuffer.PROV_END_TIMESTAMP
                     );
                     inputRs = stmt2.executeQuery(inputQuery);
                 }

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -299,7 +299,7 @@ public class ApiaryWorker {
 
         // Replay based on the commit order.
         // TODO: This may still cause an issue because transaction/commit order != actual serial order. Replay based on the correct snapshot?
-        provQuery = String.format("SELECT * FROM %s WHERE %s >= %d AND %s=0 AND %s=%s ORDER BY %s;", ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID, origTxid,
+        provQuery = String.format("SELECT * FROM %s WHERE %s >= %d AND %s=0 AND %s=\'%s\' ORDER BY %s;", ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID, origTxid,
                 ProvenanceBuffer.PROV_ISREPLAY,  ProvenanceBuffer.PROV_FUNC_STATUS, ProvenanceBuffer.PROV_STATUS_COMMIT, ProvenanceBuffer.PROV_END_TIMESTAMP);
         historyRs = stmt.executeQuery(provQuery);
 
@@ -333,7 +333,7 @@ public class ApiaryWorker {
                 if (origExecId == -1) {
                     // Get the input data.
                     String inputQuery = String.format("SELECT %s, r.%s, %s FROM %s AS r INNER JOIN %s as f ON r.%s = f.%s " +
-                                    "WHERE %s >= %d AND %s = 0 AND %s = 0 AND %s=%s ORDER BY %s;",
+                                    "WHERE %s >= %d AND %s = 0 AND %s = 0 AND %s=\'%s\' ORDER BY %s;",
                             ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID, ProvenanceBuffer.PROV_EXECUTIONID,
                             ProvenanceBuffer.PROV_REQ_BYTES, ApiaryConfig.tableRecordedInputs,
                             ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_EXECUTIONID,

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -442,7 +442,7 @@ public class ProvenanceTests {
         String resService = rs.getString(ProvenanceBuffer.PROV_SERVICE);
         String resFuncName = rs.getString(ProvenanceBuffer.PROV_PROCEDURENAME);
         assertEquals("DefaultService", resService);
-        assertEquals(PostgresProvenanceBasic.class.getName(), resFuncName);
+        assertEquals("PostgresProvenanceBasic", resFuncName);
 
         rs.next();
         long txid2 = rs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
@@ -450,7 +450,7 @@ public class ProvenanceTests {
         resService = rs.getString(ProvenanceBuffer.PROV_SERVICE);
         resFuncName = rs.getString(ProvenanceBuffer.PROV_PROCEDURENAME);
         assertEquals("DefaultService", resService);
-        assertEquals(PostgresProvenanceBasic.class.getName(), resFuncName);
+        assertEquals("PostgresProvenanceBasic", resFuncName);
 
         // Inner transaction should have the same transaction ID.
         assertEquals(txid1, txid2);

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -119,7 +119,7 @@ public class ProvenanceTests {
         long resFuncId = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
         String resFuncName = rs.getString(ProvenanceBuffer.PROV_PROCEDURENAME);
         assertTrue(resExecId >= 0);
-        assertEquals(PostgresIsSubscribed.class.getName(), resFuncName);
+        assertEquals("PostgresIsSubscribed", resFuncName);
 
         // The second function should be a subscribe function.
         rs.next();
@@ -307,7 +307,7 @@ public class ProvenanceTests {
         String resFuncName = rs.getString(ProvenanceBuffer.PROV_PROCEDURENAME);
         assertTrue(resExecId >= 0);
         assumeTrue(resFuncId == 0);
-        assertEquals(PostgresIsSubscribed.class.getName(), resFuncName);
+        assertEquals("PostgresIsSubscribed", resFuncName);
 
         // Reset the table and replay all.
         conn.truncateTable("ForumSubscription", false);
@@ -709,7 +709,7 @@ public class ProvenanceTests {
         String resService = rs.getString(ProvenanceBuffer.PROV_SERVICE);
         String resFuncName = rs.getString(ProvenanceBuffer.PROV_PROCEDURENAME);
         assertEquals("DefaultService", resService);
-        assertEquals(PostgresProvenanceMultiRows.class.getName(), resFuncName);
+        assertEquals("PostgresProvenanceMultiRows", resFuncName);
 
         // Check KVTable.
         table = "KVTableEvents";

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -322,8 +322,6 @@ public class ProvenanceTests {
         apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);
         apiaryWorker.registerFunction("PostgresIsSubscribed", ApiaryConfig.postgres, PostgresIsSubscribedTxn::new);  // Register the new one.
         // Do not register the second subscribe function.
-
-        // Register the new pipeline, so we can test the case where we have more functions.
         apiaryWorker.registerFunction("PostgresFetchSubscribers", ApiaryConfig.postgres, PostgresFetchSubscribers::new);
         apiaryWorker.startServing();
 

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -133,6 +133,7 @@ public class WordPressTests {
         // Try to reproduce the bug where the new comment comes between post trashed and comment trashed. So the new comment would be marked as trashed but cannot be restored afterwards.
         logger.info("testWPConcurrent");
         ApiaryConfig.workerAsyncDelay = true;
+        ApiaryConfig.recordInput = true;
         PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, ApiaryConfig.postgres, "dbos");
 
         apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
@@ -257,7 +258,8 @@ public class WordPressTests {
         strAryRes = client.get().retroReplay(resExecId).getStringArray();
         assertTrue(strAryRes.length > 1);
 
-        ApiaryConfig.workerAsyncDelay = false;  // Reset flag.
+        ApiaryConfig.workerAsyncDelay = false;  // Reset flags.
+        ApiaryConfig.recordInput = false;
         // Check provenance.
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
     }


### PR DESCRIPTION
This PR refactored the recording of function invocations:
- For the outmost level Postgres functions, instead of recording invocation at the beginning, it now records the function execution at the end, including two new fields: function commit time (we will need a more accurate order later) and function status. Then during replay, we skip function executions that were rolled back and retried and only replay them once.
- For inner Postgres functions, we record it as an "embedded" function, so it will not be considered as a transaction commit at the end of this function.

This PR also implemented the bug fix for WordPress. But it still has the commit order != serialization order issue. We need to fix it in our future PR.