### PR TITLE
Replay based on transaction snapshots

### DIFF
--- a/src/main/java/org/dbos/apiary/connection/ApiaryConnection.java
+++ b/src/main/java/org/dbos/apiary/connection/ApiaryConnection.java
@@ -56,7 +56,7 @@ public interface ApiaryConnection {
      */
     Map<Integer, String> getPartitionHostMap();
 
-    default Connection getRawConnection() {
+    default Connection createNewConnection() {
         return null;
     }
 
@@ -72,9 +72,9 @@ public interface ApiaryConnection {
      * @param inputs
      * @return
      */
-    default FunctionOutput replayCallFunction(Connection conn, String functionName, WorkerContext workerContext,
-                                              String service, long execID, long functionID, int replayMode,
-                                              Object... inputs) {
+    default FunctionOutput replayFunction(Connection conn, String functionName, WorkerContext workerContext,
+                                          String service, long execID, long functionID, int replayMode,
+                                          Object... inputs) {
         return null;
     }
 

--- a/src/main/java/org/dbos/apiary/connection/ApiaryConnection.java
+++ b/src/main/java/org/dbos/apiary/connection/ApiaryConnection.java
@@ -60,8 +60,21 @@ public interface ApiaryConnection {
         return null;
     }
 
-    default FunctionOutput replayCallFunction(Connection conn, String functionName, WorkerContext workerContext, String service, long execID, long functionID,
-                                int replayMode, Object... inputs) throws Exception {
+    /**
+     * for internal use only. Similar to callFunction, but is only used for replay, because the worker can explicitly specify a connection to the database.
+     * @param conn
+     * @param functionName
+     * @param workerContext
+     * @param service
+     * @param execID
+     * @param functionID
+     * @param replayMode
+     * @param inputs
+     * @return
+     */
+    default FunctionOutput replayCallFunction(Connection conn, String functionName, WorkerContext workerContext,
+                                              String service, long execID, long functionID, int replayMode,
+                                              Object... inputs) {
         return null;
     }
 

--- a/src/main/java/org/dbos/apiary/connection/ApiaryConnection.java
+++ b/src/main/java/org/dbos/apiary/connection/ApiaryConnection.java
@@ -4,6 +4,7 @@ import org.dbos.apiary.function.FunctionOutput;
 import org.dbos.apiary.function.TransactionContext;
 import org.dbos.apiary.function.WorkerContext;
 
+import java.sql.Connection;
 import java.util.Map;
 import java.util.Set;
 
@@ -54,5 +55,14 @@ public interface ApiaryConnection {
      * @return
      */
     Map<Integer, String> getPartitionHostMap();
+
+    default Connection getRawConnection() {
+        return null;
+    }
+
+    default FunctionOutput replayCallFunction(Connection conn, String functionName, WorkerContext workerContext, String service, long execID, long functionID,
+                                int replayMode, Object... inputs) throws Exception {
+        return null;
+    }
 
 }

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -50,6 +50,7 @@ public class ProvenanceBuffer {
     public static final String PROV_STATUS_ROLLBACK = "rollback";
     public static final String PROV_STATUS_ABORT = "abort";
     public static final String PROV_STATUS_EMBEDDED = "embedded";
+    public static final String PROV_STATUS_REPLAY = "replayed";
 
     /**
      * Enum class for provenance operations.

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -44,6 +44,8 @@ public class ProvenanceBuffer {
     public static final String PROV_END_TIMESTAMP = "APIARY_END_TIMESTAMP";
     // For the status column.
     public static final String PROV_FUNC_STATUS = "APIARY_FUNC_STATUS";
+    // For the transaction snapshot column.
+    public static final String PROV_TXN_SNAPSHOT = "APIARY_TXN_SNAPSHOT";
     public static final String PROV_STATUS_COMMIT = "commit";
     public static final String PROV_STATUS_ROLLBACK = "rollback";
     public static final String PROV_STATUS_ABORT = "abort";

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -296,18 +296,19 @@ public class PostgresConnection implements ApiaryConnection {
     }
 
     @Override
-    public FunctionOutput replayCallFunction(Connection conn, String functionName, WorkerContext workerContext, String service, long execID, long functionID,
-                                      int replayMode, Object... inputs) {
+    public FunctionOutput replayCallFunction(Connection conn, String functionName, WorkerContext workerContext,
+                                             String service, long execID, long functionID,int replayMode,
+                                             Object... inputs) {
         // Fast path for replayed functions.
-        FunctionOutput f = null;
+        FunctionOutput f;
         long startTime = Utilities.getMicroTimestamp();
         PostgresContext ctxt = new PostgresContext(conn, workerContext, service, execID, functionID, replayMode,
-                new HashSet<>(activeTransactions), new HashSet<>(abortedTransactions));
+                new HashSet<>(), new HashSet<>());
         try {
             f = workerContext.getFunction(functionName).apiaryRunFunction(ctxt, inputs);
         } catch (Exception e) {
             // TODO: better error handling? For now, ignore those errors.
-            logger.warn("Failed execution. Skipped.");
+            logger.warn("Failed execution during replay.");
             recordTransactionInfo(workerContext, ctxt, startTime, functionName, ProvenanceBuffer.PROV_STATUS_ABORT);
             return null;
         }

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -54,7 +54,7 @@ public class PostgresConnection implements ApiaryConnection {
         this.ds.setSsl(false);
 
         logger.info("Postgres isolation level: {}", ApiaryConfig.isolationLevel);
-        this.connection = ThreadLocal.withInitial(() -> getRawConnection());
+        this.connection = ThreadLocal.withInitial(() -> createNewConnection());
         this.bgConnection = ThreadLocal.withInitial(() -> {
             try {
                 Connection conn = ds.getConnection();
@@ -192,7 +192,7 @@ public class PostgresConnection implements ApiaryConnection {
     }
 
     @Override
-    public Connection getRawConnection() {
+    public Connection createNewConnection() {
         try {
             Connection conn = ds.getConnection();
             conn.setAutoCommit(false);
@@ -296,9 +296,9 @@ public class PostgresConnection implements ApiaryConnection {
     }
 
     @Override
-    public FunctionOutput replayCallFunction(Connection conn, String functionName, WorkerContext workerContext,
-                                             String service, long execID, long functionID,int replayMode,
-                                             Object... inputs) {
+    public FunctionOutput replayFunction(Connection conn, String functionName, WorkerContext workerContext,
+                                         String service, long execID, long functionID, int replayMode,
+                                         Object... inputs) {
         // Fast path for replayed functions.
         FunctionOutput f;
         long startTime = Utilities.getMicroTimestamp();

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -104,10 +104,11 @@ public class PostgresConnection implements ApiaryConnection {
                 + ProvenanceBuffer.PROV_EXECUTIONID + " BIGINT NOT NULL, "
                 + ProvenanceBuffer.PROV_FUNCID + " BIGINT NOT NULL, "
                 + ProvenanceBuffer.PROV_ISREPLAY + " SMALLINT NOT NULL, "
-                + ProvenanceBuffer.PROV_SERVICE + " VARCHAR(1024) NOT NULL, "
-                + ProvenanceBuffer.PROV_PROCEDURENAME + " VARCHAR(1024) NOT NULL, "
+                + ProvenanceBuffer.PROV_SERVICE + " VARCHAR(256) NOT NULL, "
+                + ProvenanceBuffer.PROV_PROCEDURENAME + " VARCHAR(512) NOT NULL, "
                 + ProvenanceBuffer.PROV_END_TIMESTAMP + " BIGINT, "
-                + ProvenanceBuffer.PROV_FUNC_STATUS + " VARCHAR(20) ");
+                + ProvenanceBuffer.PROV_FUNC_STATUS + " VARCHAR(20), "
+                + ProvenanceBuffer.PROV_TXN_SNAPSHOT + " VARCHAR(1024) ");
         createTable(ProvenanceBuffer.PROV_ApiaryMetadata,
                 "Key VARCHAR(1024) NOT NULL, Value Integer, PRIMARY KEY(key)");
         createTable(ProvenanceBuffer.PROV_QueryMetadata,
@@ -349,6 +350,7 @@ public class PostgresConnection implements ApiaryConnection {
                 logger.error("Failed to get commit timestamp.");
             }
         }
-        workerContext.provBuff.addEntry(ApiaryConfig.tableFuncInvocations, ctxt.txc.txID, startTime, ctxt.execID, ctxt.functionID, (short)ctxt.replayMode, ctxt.service, functionName, commitTime, status);
+        String txnSnapshot = PostgresUtilities.constuctSnapshotStr(ctxt.txc.xmin, ctxt.txc.xmax, ctxt.txc.activeTransactions);
+        workerContext.provBuff.addEntry(ApiaryConfig.tableFuncInvocations, ctxt.txc.txID, startTime, ctxt.execID, ctxt.functionID, (short)ctxt.replayMode, ctxt.service, functionName, commitTime, status, txnSnapshot);
     }
 }

--- a/src/main/java/org/dbos/apiary/postgres/PostgresUtilities.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresUtilities.java
@@ -39,4 +39,11 @@ public class PostgresUtilities {
             return new ArrayList<>();
         }
     }
+
+    public static String constuctSnapshotStr(long xmin, long xmax, List<Long> activeTxns) {
+        List<String> activeStr = activeTxns.stream()
+                .map(String::valueOf)
+                .collect(Collectors.toList());
+        return String.format("%d:%d:%s", xmin, xmax, String.join(",", activeStr));
+    }
 }

--- a/src/main/java/org/dbos/apiary/utilities/ApiaryConfig.java
+++ b/src/main/java/org/dbos/apiary/utilities/ApiaryConfig.java
@@ -58,7 +58,5 @@ public class ApiaryConfig {
     public static Boolean recordInput = false;  // If true, capture input of the entry function and record in a table.
     public static final String tableRecordedInputs = "RECORDEDINPUTS";
 
-    // For fault injection.
-    public static Boolean workerAsyncDelay = false;  // If true, add a few milliseconds of delay between async function invocations.
     public static Boolean trackCommitTimestamp = false;  // If true, Postgres is configured to track commit timestamp of each transaction.
 }

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -483,6 +483,7 @@ public class ApiaryWorker {
             fo = c.replayCallFunction(conn, funcName, workerContext, "retroReplay", execId, funcId,
                     replayMode, inputs);
             if (fo == null) {
+                logger.warn("Repaly function output is null.");
                 return false;
             }
             execFuncIdToValue.putIfAbsent(execId, new HashMap<>());
@@ -511,6 +512,7 @@ public class ApiaryWorker {
             // Remove this task from the map.
             pendingTasks.get(execId).remove(funcId);
             if (fo == null) {
+                logger.warn("Repaly function output is null.");
                 return false; // TODO: better error handling?
             }
         }

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -445,14 +445,15 @@ public class ApiaryWorker {
         FunctionOutput fo;
         // Only support primary functions.
         if (!workerContext.functionExists(funcName)) {
-            logger.error("Unrecognized function: {}, cannot replay.", funcName);
-            throw new RuntimeException("Unrecognized function, cannot replay.");
+            logger.info("Unrecognized function: {}, cannot replay, skipped.", funcName);
+            return false;
         }
         String type = workerContext.getFunctionType(funcName);
         if (!workerContext.getPrimaryConnectionType().equals(type)) {
             logger.error("Replay only support primary functions!");
             throw new RuntimeException("Replay only support primary functions!");
         }
+
         ApiaryConnection c = workerContext.getPrimaryConnection();
 
         if (funcId == 0l) {

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -480,7 +480,7 @@ public class ApiaryWorker {
 
         if (funcId == 0l) {
             // This is the first function of a request.
-            fo = c.replayCallFunction(conn, funcName, workerContext, "retroReplay", execId, funcId,
+            fo = c.replayFunction(conn, funcName, workerContext, "retroReplay", execId, funcId,
                     replayMode, inputs);
             if (fo == null) {
                 logger.warn("Repaly function output is null.");
@@ -507,7 +507,7 @@ public class ApiaryWorker {
                 throw new RuntimeException("Retro replay failed to dereference input.");
             }
 
-            fo = c.replayCallFunction(conn, currTask.funcName, workerContext,  "retroReplay", execId, funcId,
+            fo = c.replayFunction(conn, currTask.funcName, workerContext,  "retroReplay", execId, funcId,
                     replayMode, currTask.input);
             // Remove this task from the map.
             pendingTasks.get(execId).remove(funcId);

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -357,7 +357,7 @@ public class ApiaryWorker {
         assert (commitOrderRs.next());
         long nextCommitTxid = commitOrderRs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
 
-        while (commitOrderRs.next()) {
+        while (nextCommitTxid > 0) {
             // Execute until nextCommitTxid is in the snapshot of that original transaction.
             while (true) {
                 long resTxId = startOrderRs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
@@ -411,7 +411,11 @@ public class ApiaryWorker {
             commitConn.commit();
             connPool.add(commitConn);
             pendingCommits.remove(nextCommitTxid);
-            nextCommitTxid = commitOrderRs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
+            if (commitOrderRs.next()) {
+                nextCommitTxid = commitOrderRs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
+            } else {
+                nextCommitTxid = 0;
+            }
         }
 
         if (!pendingTasks.isEmpty()) {

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -166,10 +166,6 @@ public class ApiaryWorker {
                             workerContext.getPrimaryConnection().getPartitionHostMap().get(0)
                             : workerContext.getPrimaryConnection().getHostname(subtask.input);
                     // Push to the outgoing queue.
-                    if (ApiaryConfig.workerAsyncDelay) {
-                        // Add some delay if we are trying to do fault injection.
-                        Thread.sleep(ThreadLocalRandom.current().nextInt(10));
-                    }
                     byte[] reqBytes = InternalApiaryWorkerClient.serializeExecuteRequest(subtask.funcName, currTask.service, currTask.execId, currTask.replayMode, currCallerID, subtask.functionID, subtask.input);
                     outgoingReqMsgQueue.add(new OutgoingMsg(address, reqBytes));
                 }

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -349,7 +349,7 @@ public class ApiaryWorker {
         int connPoolSize = 10;  // Connection pool size. TODO: tune this.
         Queue<Connection> connPool = new ConcurrentLinkedQueue<>();
         for (int i = 0; i < connPoolSize; i++) {
-            connPool.add(workerContext.getPrimaryConnection().getRawConnection());
+            connPool.add(workerContext.getPrimaryConnection().createNewConnection());
         }
 
         // A pending commit map from transaction ID to connection. <txid, connection>

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -399,7 +399,10 @@ public class ApiaryWorker {
                     // TODO: optimize for empty transactions?
                     processReplayFunction(currConn, resExecId, resFuncId, resName, replayMode, currInputs, pendingTasks, execFuncIdToValue, execIdToFinalOutput);
                     pendingCommits.put(resTxId, currConn);
-                    startOrderRs.next();  // Process the next one.
+                    if (!startOrderRs.next()) {
+                        // No more to process.
+                        break;
+                    }
                 } else {
                     break;  // Need to wait until nextCommitTxid to commit.
                 }

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -411,7 +411,12 @@ public class ApiaryWorker {
             // Commit the nextCommitTxid and update the variables.
             Connection commitConn = pendingCommits.get(nextCommitTxid);
             assert (commitConn != null);
-            commitConn.commit();
+            try {
+                commitConn.commit();
+            } catch (Exception e) {
+                // TODO: how to handle commit failures? Now assume they are serialization errors.
+                logger.warn("Failed to commit {}, skipped.", nextCommitTxid);
+            }
             connPool.add(commitConn);
             pendingCommits.remove(nextCommitTxid);
             if (commitOrderRs.next()) {

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -311,7 +311,7 @@ public class ApiaryWorker {
         assert (startOrderRs.next());  // Should have at least one execution.
 
         // This query finds the commit order of transactions.
-        String commitOrderQuery = String.format("SELECT %s, %s FROM %s WHERE %s >= %d AND %s=0 AND %s=\'%s\' ORDERY BY %s;", ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID, ProvenanceBuffer.PROV_EXECUTIONID,
+        String commitOrderQuery = String.format("SELECT %s, %s FROM %s WHERE %s >= %d AND %s=0 AND %s=\'%s\' ORDER BY %s;", ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID, ProvenanceBuffer.PROV_EXECUTIONID,
                 ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID, origTxid,
                 ProvenanceBuffer.PROV_ISREPLAY,  ProvenanceBuffer.PROV_FUNC_STATUS, ProvenanceBuffer.PROV_STATUS_COMMIT, ProvenanceBuffer.PROV_END_TIMESTAMP);
         Statement commitOrderStmt = conn.createStatement();

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -459,7 +459,9 @@ public class ApiaryWorker {
         if (funcId == 0l) {
             // This is the first function of a request.
             fo = c.replayCallFunction(conn, funcName, workerContext, "retroReplay", execId, funcId, replayMode, inputs);
-            assert (fo != null);
+            if (fo == null) {
+                return false;
+            }
             execFuncIdToValue.putIfAbsent(execId, new HashMap<>());
             execIdToFinalOutput.putIfAbsent(execId, fo.output);
             pendingTasks.putIfAbsent(execId, new HashMap<>());
@@ -481,9 +483,11 @@ public class ApiaryWorker {
             }
 
             fo = c.replayCallFunction(conn, currTask.funcName, workerContext,  "retroReplay", execId, funcId, replayMode, currTask.input);
-            assert (fo != null);
             // Remove this task from the map.
             pendingTasks.get(execId).remove(funcId);
+            if (fo == null) {
+                return false; // TODO: better error handling?
+            }
         }
         // Store output value.
         execFuncIdToValue.get(execId).putIfAbsent(funcId, fo.output);

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -324,7 +324,7 @@ public class ApiaryWorker {
                 ProvenanceBuffer.PROV_REQ_BYTES, ApiaryConfig.tableRecordedInputs,
                 ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_EXECUTIONID,
                 ProvenanceBuffer.PROV_EXECUTIONID, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID,
-                origExecId, ProvenanceBuffer.PROV_FUNCID, ProvenanceBuffer.PROV_ISREPLAY,  ProvenanceBuffer.PROV_FUNC_STATUS, ProvenanceBuffer.PROV_STATUS_COMMIT,
+                origTxid, ProvenanceBuffer.PROV_FUNCID, ProvenanceBuffer.PROV_ISREPLAY,  ProvenanceBuffer.PROV_FUNC_STATUS, ProvenanceBuffer.PROV_STATUS_COMMIT,
                 ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID
         );
         Statement inputStmt = conn.createStatement();

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -42,6 +42,11 @@ public class ProvenanceTests {
 
     @BeforeAll
     public static void testConnection() {
+        // Set the isolation level to serializable.
+        ApiaryConfig.isolationLevel = ApiaryConfig.SERIALIZABLE;
+        // Disable XDB transactions.
+        ApiaryConfig.XDBTransactions = false;
+
         assumeTrue(TestUtils.testPostgresConnection());
         ApiaryConfig.recordInput = true;
     }

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -132,7 +132,6 @@ public class WordPressTests {
     public void testWPConcurrentRetro() throws SQLException, InvalidProtocolBufferException, InterruptedException {
         // Try to reproduce the bug where the new comment comes between post trashed and comment trashed. So the new comment would be marked as trashed but cannot be restored afterwards.
         logger.info("testWPConcurrentRetro");
-        ApiaryConfig.workerAsyncDelay = true;
         ApiaryConfig.recordInput = true;
         PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, ApiaryConfig.postgres, "dbos");
 
@@ -283,8 +282,8 @@ public class WordPressTests {
         strAryRes = client.get().retroReplay(resExecId).getStringArray();
         assertEquals(1, strAryRes.length);
 
-        ApiaryConfig.workerAsyncDelay = false;  // Reset flags.
-        ApiaryConfig.recordInput = false;
+        ApiaryConfig.recordInput = false; // Reset flags.
+
         // Check provenance.
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
     }


### PR DESCRIPTION
This PR fixed the issue where replaying using transaction or commit order can cause diverging results. The core issue is that we need to mock the original concurrent transactions.

Therefore, we record transaction snapshot information and during replay, faithfully re-construct the concurrent execution scenarios using parallel connections to the backend database.