### PR TITLE
Selective Retro

### DIFF
--- a/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
+++ b/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
@@ -217,7 +217,7 @@ public class RetroBenchmark {
             int res = client.get().replayFunction(targetExecId, "MDLIsSubscribed", initialUserId, initialForumId).getInt();
             assert (res == initialUserId);
         } else if (replayMode == ApiaryConfig.ReplayMode.ALL.getValue()){
-            FunctionOutput res = client.get().retroReplay(targetExecId);
+            FunctionOutput res = client.get().retroReplay(targetExecId, ApiaryConfig.ReplayMode.ALL.getValue());
             assert (res != null);
         } else {
             logger.error("Do not support replay mode {}", replayMode);

--- a/src/main/java/org/dbos/apiary/client/ApiaryWorkerClient.java
+++ b/src/main/java/org/dbos/apiary/client/ApiaryWorkerClient.java
@@ -95,12 +95,14 @@ public class ApiaryWorkerClient {
 
     /**
      * Replay the execution and everything after it using the original execution trace. Block waiting for the result of the last execution. The replay will not generate new provenance data.
+     *
      * @param execId    the original execution ID of the target request.
-     * @return          the output of the last execution.
+     * @param retroMode the mode of replay. See {@link ApiaryConfig.ReplayMode}
+     * @return the output of the last execution.
      * @throws InvalidProtocolBufferException
      */
-    public FunctionOutput retroReplay(long execId) throws InvalidProtocolBufferException {
-        return internalClient.executeFunction(this.apiaryWorkerAddress, "retroReplay", "DefaultService", execId, ApiaryConfig.ReplayMode.ALL.getValue(), null);
+    public FunctionOutput retroReplay(long execId, int retroMode) throws InvalidProtocolBufferException {
+        return internalClient.executeFunction(this.apiaryWorkerAddress, "retroReplay", "DefaultService", execId, retroMode, null);
     }
 
     /**

--- a/src/main/java/org/dbos/apiary/connection/ApiaryConnection.java
+++ b/src/main/java/org/dbos/apiary/connection/ApiaryConnection.java
@@ -73,7 +73,7 @@ public interface ApiaryConnection {
      * @return
      */
     default FunctionOutput replayFunction(Connection conn, String functionName, WorkerContext workerContext,
-                                          String service, long execID, long functionID, int replayMode,
+                                          String service, long execID, long functionID, int replayMode, Set<String> replayWrittenTables,
                                           Object... inputs) {
         return null;
     }

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -46,6 +46,7 @@ public class ProvenanceBuffer {
     public static final String PROV_FUNC_STATUS = "APIARY_FUNC_STATUS";
     // For the transaction snapshot column.
     public static final String PROV_TXN_SNAPSHOT = "APIARY_TXN_SNAPSHOT";
+    public static final String PROV_READONLY = "APIARY_READONLY";
     public static final String PROV_STATUS_COMMIT = "commit";
     public static final String PROV_STATUS_ROLLBACK = "rollback";
     public static final String PROV_STATUS_ABORT = "abort";

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -302,7 +302,8 @@ public class ProvenanceBuffer {
         } else if (colType == Types.BINARY) {
             // The bytea type.
             pstmt.setBytes(colIndex, (byte[]) val);
-        } else if (colType == Types.BOOLEAN) {
+        } else if ((colType == Types.BOOLEAN) || (colType == Types.BIT)) {
+            // Somehow Postgres JDBC uses BIT type.
             boolean boolVal = false;
             if (val instanceof Boolean) {
                 boolVal = (Boolean) val;

--- a/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
+++ b/src/main/java/org/dbos/apiary/function/ProvenanceBuffer.java
@@ -302,6 +302,16 @@ public class ProvenanceBuffer {
         } else if (colType == Types.BINARY) {
             // The bytea type.
             pstmt.setBytes(colIndex, (byte[]) val);
+        } else if (colType == Types.BOOLEAN) {
+            boolean boolVal = false;
+            if (val instanceof Boolean) {
+                boolVal = (Boolean) val;
+            } else if (val instanceof String) {
+                boolVal = Boolean.parseBoolean((String) val);
+            } else {
+                boolVal = ((Long) val == 0);
+            }
+            pstmt.setBoolean(colIndex, boolVal);
         } else {
             // Everything else will be passed directly as string.
             logger.warn(String.format("Failed to convert type: %d. Use String", colType));

--- a/src/main/java/org/dbos/apiary/function/StatelessFunction.java
+++ b/src/main/java/org/dbos/apiary/function/StatelessFunction.java
@@ -15,6 +15,6 @@ public class StatelessFunction implements ApiaryFunction {
             return;
         }
         long timestamp = Utilities.getMicroTimestamp();
-        ctxt.workerContext.provBuff.addEntry(ApiaryConfig.tableFuncInvocations, ApiaryConfig.statelessTxid, timestamp, ctxt.execID, ctxt.service, funcName);
+        ctxt.workerContext.provBuff.addEntry(ApiaryConfig.tableFuncInvocations, ApiaryConfig.statelessTxid, timestamp, ctxt.execID, ctxt.service, funcName, /*readonly=*/true);
     }
 }

--- a/src/main/java/org/dbos/apiary/function/TransactionContext.java
+++ b/src/main/java/org/dbos/apiary/function/TransactionContext.java
@@ -10,6 +10,7 @@ public class TransactionContext {
     public final long xmax;
     public final List<Long> activeTransactions;
     public final AtomicInteger querySeqNum;  // Query sequence number within a transaction, starting from 0.
+    public boolean readOnly = true;  // If true, transaction is read-only.
 
     public TransactionContext(long txID, long xmin, long xmax, List<Long> activeTransactions) {
         this.txID = txID;

--- a/src/main/java/org/dbos/apiary/function/WorkerContext.java
+++ b/src/main/java/org/dbos/apiary/function/WorkerContext.java
@@ -65,6 +65,8 @@ public class WorkerContext {
         return functions.containsKey(function);
     }
 
+    public boolean retroFunctionExists(String function) { return retroFunctions.containsKey(function); }
+
     public ApiaryFunction getFunction(String function) {
         try {
             return functions.get(function).call();

--- a/src/main/java/org/dbos/apiary/function/WorkerContext.java
+++ b/src/main/java/org/dbos/apiary/function/WorkerContext.java
@@ -67,6 +67,8 @@ public class WorkerContext {
 
     public boolean retroFunctionExists(String function) { return retroFunctions.containsKey(function); }
 
+    public boolean hasRetroFunctions() { return !retroFunctions.isEmpty(); }
+
     public ApiaryFunction getFunction(String function) {
         try {
             return functions.get(function).call();

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -304,8 +304,7 @@ public class PostgresConnection implements ApiaryConnection {
                 new HashSet<>(), new HashSet<>());
         try {
             ApiaryFunction func = workerContext.getFunction(functionName);
-            String[] actualNames = func.getClassName().split("\\.");
-            actualName = actualNames[actualNames.length-1];
+            actualName = Utilities.getFunctionClassName(func);
             logger.debug("Replaying function [{}], inputs {}", actualName, inputs);
             f = func.apiaryRunFunction(ctxt, inputs);
             logger.debug("Completed function [{}]", actualName);

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -303,7 +303,7 @@ public class PostgresConnection implements ApiaryConnection {
         String actualName = functionName;
         long startTime = Utilities.getMicroTimestamp();
         PostgresContext ctxt = new PostgresContext(conn, workerContext, service, execID, functionID, replayMode,
-                new HashSet<>(), new HashSet<>(), new HashSet<>(replayWrittenTables));
+                new HashSet<>(), new HashSet<>(), new HashSet<>());
         try {
             ApiaryFunction func = workerContext.getFunction(functionName);
             actualName = Utilities.getFunctionClassName(func);
@@ -318,7 +318,7 @@ public class PostgresConnection implements ApiaryConnection {
         }
 
         recordTransactionInfo(workerContext, ctxt, startTime, actualName, ProvenanceBuffer.PROV_STATUS_REPLAY);
-        // TODO: fix this redundancy.
+        // Collect all written tables.
         replayWrittenTables.addAll(ctxt.replayWrittenTables);
         return f;
     }

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -89,7 +89,8 @@ public class PostgresConnection implements ApiaryConnection {
                 + ProvenanceBuffer.PROV_PROCEDURENAME + " VARCHAR(512) NOT NULL, "
                 + ProvenanceBuffer.PROV_END_TIMESTAMP + " BIGINT, "
                 + ProvenanceBuffer.PROV_FUNC_STATUS + " VARCHAR(20), "
-                + ProvenanceBuffer.PROV_TXN_SNAPSHOT + " VARCHAR(1024) ");
+                + ProvenanceBuffer.PROV_TXN_SNAPSHOT + " VARCHAR(1024), "
+                + ProvenanceBuffer.PROV_READONLY + "BOOLEAN NOT NULL ");
         createTable(ProvenanceBuffer.PROV_ApiaryMetadata,
                 "Key VARCHAR(1024) NOT NULL, Value Integer, PRIMARY KEY(key)");
         createTable(ProvenanceBuffer.PROV_QueryMetadata,
@@ -378,6 +379,6 @@ public class PostgresConnection implements ApiaryConnection {
             }
         }
         String txnSnapshot = PostgresUtilities.constuctSnapshotStr(ctxt.txc.xmin, ctxt.txc.xmax, ctxt.txc.activeTransactions);
-        workerContext.provBuff.addEntry(ApiaryConfig.tableFuncInvocations, ctxt.txc.txID, startTime, ctxt.execID, ctxt.functionID, (short)ctxt.replayMode, ctxt.service, functionName, commitTime, status, txnSnapshot);
+        workerContext.provBuff.addEntry(ApiaryConfig.tableFuncInvocations, ctxt.txc.txID, startTime, ctxt.execID, ctxt.functionID, (short)ctxt.replayMode, ctxt.service, functionName, commitTime, status, txnSnapshot, ctxt.txc.readOnly);
     }
 }

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -318,6 +318,8 @@ public class PostgresConnection implements ApiaryConnection {
         }
 
         recordTransactionInfo(workerContext, ctxt, startTime, actualName, ProvenanceBuffer.PROV_STATUS_REPLAY);
+        // TODO: fix this redundancy.
+        replayWrittenTables.addAll(ctxt.replayWrittenTables);
         return f;
     }
 

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -90,7 +90,7 @@ public class PostgresConnection implements ApiaryConnection {
                 + ProvenanceBuffer.PROV_END_TIMESTAMP + " BIGINT, "
                 + ProvenanceBuffer.PROV_FUNC_STATUS + " VARCHAR(20), "
                 + ProvenanceBuffer.PROV_TXN_SNAPSHOT + " VARCHAR(1024), "
-                + ProvenanceBuffer.PROV_READONLY + " BOOLEAN NOT NULL ");
+                + ProvenanceBuffer.PROV_READONLY + " BOOLEAN ");
         createTable(ProvenanceBuffer.PROV_ApiaryMetadata,
                 "Key VARCHAR(1024) NOT NULL, Value Integer, PRIMARY KEY(key)");
         createTable(ProvenanceBuffer.PROV_QueryMetadata,

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -90,7 +90,7 @@ public class PostgresConnection implements ApiaryConnection {
                 + ProvenanceBuffer.PROV_END_TIMESTAMP + " BIGINT, "
                 + ProvenanceBuffer.PROV_FUNC_STATUS + " VARCHAR(20), "
                 + ProvenanceBuffer.PROV_TXN_SNAPSHOT + " VARCHAR(1024), "
-                + ProvenanceBuffer.PROV_READONLY + "BOOLEAN NOT NULL ");
+                + ProvenanceBuffer.PROV_READONLY + " BOOLEAN NOT NULL ");
         createTable(ProvenanceBuffer.PROV_ApiaryMetadata,
                 "Key VARCHAR(1024) NOT NULL, Value Integer, PRIMARY KEY(key)");
         createTable(ProvenanceBuffer.PROV_QueryMetadata,

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -218,7 +218,7 @@ public class PostgresConnection implements ApiaryConnection {
             long startTime = Utilities.getMicroTimestamp();
             activeTransactionsLock.readLock().lock();
             PostgresContext ctxt = new PostgresContext(c, workerContext, service, execID, functionID, replayMode,
-                    new HashSet<>(activeTransactions), new HashSet<>(abortedTransactions));
+                    new HashSet<>(activeTransactions), new HashSet<>(abortedTransactions), new HashSet<>());
             activeTransactions.add(ctxt.txc);
             latestTransactionContext = ctxt.txc;
             if (ctxt.txc.xmin > biggestxmin) {
@@ -296,13 +296,14 @@ public class PostgresConnection implements ApiaryConnection {
     @Override
     public FunctionOutput replayFunction(Connection conn, String functionName, WorkerContext workerContext,
                                          String service, long execID, long functionID, int replayMode,
+                                         Set<String> replayWrittenTables,
                                          Object... inputs) {
         // Fast path for replayed functions.
         FunctionOutput f;
         String actualName = functionName;
         long startTime = Utilities.getMicroTimestamp();
         PostgresContext ctxt = new PostgresContext(conn, workerContext, service, execID, functionID, replayMode,
-                new HashSet<>(), new HashSet<>());
+                new HashSet<>(), new HashSet<>(), new HashSet<>(replayWrittenTables));
         try {
             ApiaryFunction func = workerContext.getFunction(functionName);
             actualName = Utilities.getFunctionClassName(func);

--- a/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
@@ -26,7 +26,7 @@ public class PostgresContext extends ApiaryContext {
 
     private final long replayTxID;  // The replayed transaction ID.
 
-    private final Set<String> replayWrittenTables;
+    public final Set<String> replayWrittenTables;
 
     private static final String checkReplayTxID = String.format("SELECT %s FROM %s WHERE %s=? AND %s=? AND %s=0", ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID,
             ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_EXECUTIONID, ProvenanceBuffer.PROV_FUNCID, ProvenanceBuffer.PROV_ISREPLAY);

--- a/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
@@ -10,9 +10,7 @@ import org.slf4j.LoggerFactory;
 import java.sql.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * PostgresContext is a context for Apiary-Postgres functions.

--- a/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresContext.java
@@ -151,6 +151,7 @@ public class PostgresContext extends ApiaryContext {
      * @param input     input parameters for the SQL statement.
      */
     public void executeUpdate(String procedure, Object... input) throws SQLException {
+        txc.readOnly = false;
         // Replay.
         if (this.replayMode == ApiaryConfig.ReplayMode.SINGLE.getValue()) {
             replayUpdate(procedure, input);
@@ -209,6 +210,7 @@ public class PostgresContext extends ApiaryContext {
      * @param inputs     an array of input parameters for the SQL statement.
      */
     public void insertMany(String procedure, List<Object[]> inputs) throws SQLException {
+        txc.readOnly = false;
         PreparedStatement pstmt = conn.prepareStatement(procedure);
         for (Object[] input : inputs) {
             prepareStatement(pstmt, input);
@@ -216,7 +218,6 @@ public class PostgresContext extends ApiaryContext {
         }
         pstmt.executeBatch();
         pstmt.close();
-        return;
     }
 
     /**

--- a/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
@@ -208,7 +208,7 @@ public class PostgresRetroReplay {
                 } catch (Exception e) {
                     // Retry the pending commit function if it's a serialization error.
                     // Note: this should only happen during retroactive programming. Because normal replay should only replay originally committed transactions.
-                    if (e instanceof PSQLException) {
+                    if ((e instanceof PSQLException) && (workerContext.hasRetroFunctions())) {
                         PSQLException p = (PSQLException) e;
                         if (p.getSQLState().equals(PSQLState.SERIALIZATION_FAILURE.getState())) {
                             logger.debug("Retry transaction {} due to serilization error. ", nextCommitTxid);

--- a/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
@@ -226,11 +226,12 @@ public class PostgresRetroReplay {
                         }
                     }
                 }
+                // Put it back to the connection pool and delete stored inputs.
+                connPool.add(commitConn);
+                pendingCommits.remove(nextCommitTxid);
+                pendingCommitTask.remove(nextCommitTxid);
             }
-            // Put it back to the connection pool and delete stored inputs.
-            connPool.add(commitConn);
-            pendingCommits.remove(nextCommitTxid);
-            pendingCommitTask.remove(nextCommitTxid);
+
             if (commitOrderRs.next()) {
                 nextCommitTxid = commitOrderRs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
             } else {

--- a/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
@@ -285,7 +285,7 @@ public class PostgresRetroReplay {
         // The current selective replay heuristic:
         // 1) If a request has been skipped, then all following functions will be skipped.
         // 2) If a function name is in the list of retroFunctions, then we cannot skip.
-        // 3) Cannot skip functions that contain writes.
+        // 3) Cannot skip a request if any of its function contains writes.
         // TODO: update heuristics, improve it.
         if (skippedExecIds.contains(rpTask.execId)) {
             return true;
@@ -297,6 +297,9 @@ public class PostgresRetroReplay {
         }
 
         if (!rpTask.readOnly) {
+            // TODO: need to improve this because the first function of a request might be read-only, but the downstream contains write.
+            // Also, the issue is that a function sometimes could become read-only if the write query is not executed. We should check all function invocations.
+            // Maybe even decide a function is read-only or not during registration.
             return false;
         }
 

--- a/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
@@ -167,7 +167,8 @@ public class PostgresRetroReplay {
 
                     boolean isSkipped = checkSkipFunc(workerContext, rpTask, skippedExecIds, replayMode);
 
-                    if (isSkipped) {
+                    if (isSkipped && (lastNonSkippedExecId != -1)) {
+                        // Do not skip the first execution.
                         logger.debug("Skipping transaction {}, execution ID {}", resTxId, resExecId);
                         skippedExecIds.add(resExecId);
                     } else {

--- a/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
@@ -329,7 +329,7 @@ public class PostgresRetroReplay {
                     ProvenanceBuffer.PROV_EXECUTIONID, ProvenanceBuffer.PROV_ISREPLAY);
             PreparedStatement tablePstmt = provConn.prepareStatement(tableQuery);
             tablePstmt.setLong(1, rpTask.execId);
-            ResultSet tableRs = pstmt.executeQuery();
+            ResultSet tableRs = tablePstmt.executeQuery();
 
             if (!tableRs.next()) {
                 // Not found, but to be cautious we have to replay it.

--- a/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
@@ -323,9 +323,10 @@ public class PostgresRetroReplay {
             // TODO: need to improve this: the issue is that a function sometimes could become read-only if the write query is not executed. The best way is to do static analysis.
             // If a request contains write but has nothing to do with the related table, we can skip it.
             // Check query metadata table and see if any transaction related to this execution touches any written tables.
-            String tableQuery = String.format("select %s from %s AS r inner join %s AS f on r.%s = f.%s WHERE f.%s=? and %s=0;",
+            String tableQuery = String.format("select %s from %s AS r inner join %s AS f on r.%s = f.%s WHERE f.%s = ? and %s=0;",
                     ProvenanceBuffer.PROV_QUERY_TABLENAMES, ProvenanceBuffer.PROV_QueryMetadata, ApiaryConfig.tableFuncInvocations,
-                    ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID, ProvenanceBuffer.PROV_EXECUTIONID, ProvenanceBuffer.PROV_ISREPLAY);
+                    ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID,
+                    ProvenanceBuffer.PROV_EXECUTIONID, ProvenanceBuffer.PROV_ISREPLAY);
             PreparedStatement tablePstmt = provConn.prepareStatement(tableQuery);
             tablePstmt.setLong(1, rpTask.execId);
             ResultSet tableRs = pstmt.executeQuery();

--- a/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
@@ -288,11 +288,12 @@ public class PostgresRetroReplay {
             return true;
         }
 
-        if (!workerContext.retroFunctionExists(rpTask.funcName)) {
-            return true;
+        if (workerContext.retroFunctionExists(rpTask.funcName)) {
+            // Always replay modified functions.
+            return false;
         }
 
-        return false;
+        return true;
     }
 
     // Return true if executed the function, false if nothing executed.

--- a/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
@@ -277,11 +277,12 @@ public class PostgresRetroReplay {
 
     // Return true if the function execution can be skipped.
     private static boolean checkSkipFunc(WorkerContext workerContext, ReplayTask rpTask, Set<Long> skippedExecIds, int replayMode, Set<String> replayWrittenTables) throws SQLException {
-        logger.debug("Replay written tables: {}", replayWrittenTables.toString());
         if (replayMode == ApiaryConfig.ReplayMode.ALL.getValue()) {
             // Do not skip if we are replaying everything.
             return false;
         }
+
+        logger.debug("Replay written tables: {}", replayWrittenTables.toString());
 
         // The current selective replay heuristic:
         // 1) If a request has been skipped, then all following functions will be skipped.
@@ -320,7 +321,9 @@ public class PostgresRetroReplay {
         pstmt.close();
         if (!isReadOnly) {
             // TODO: need to improve this: the issue is that a function sometimes could become read-only if the write query is not executed. The best way is to do static analysis.
-            // TODO: implement logic where if a request has nothing to do with the related table, we can skip it even if it contains writes.
+            // If a request contains write but has nothing to do with the related table, we can skip it. Check query metadata table and see if any transaction related to this execution touches the written table.
+
+
             return false;
         }
 

--- a/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
@@ -164,7 +164,7 @@ public class PostgresRetroReplay {
 
                     // Check if we can skip this function execution. If so, add to the skip list. Otherwise, execute the replay.
 
-                    boolean isSkipped = checkSkipFunc(workerContext, rpTask, skippedExecIds);
+                    boolean isSkipped = checkSkipFunc(workerContext, rpTask, skippedExecIds, replayMode);
 
                     if (isSkipped) {
                         logger.debug("Skipping transaction {}, execution ID {}", resTxId, resExecId);
@@ -272,8 +272,13 @@ public class PostgresRetroReplay {
     }
 
     // Return true if the function execution can be skipped.
-    private static boolean checkSkipFunc(WorkerContext workerContext, ReplayTask rpTask, Set<Long> skippedExecIds) {
-        // The current heuristic:
+    private static boolean checkSkipFunc(WorkerContext workerContext, ReplayTask rpTask, Set<Long> skippedExecIds, int replayMode) {
+        if (replayMode == ApiaryConfig.ReplayMode.ALL.getValue()) {
+            // Do not skip if we are replaying everything.
+            return false;
+        }
+
+        // The current selective replay heuristic:
         // 1) If a request has been skipped, then all following functions will be skipped.
         // 2) If a function name is not in the list of retroFunctions, then we can skip. TODO: update this because a function may not be in retroFunctions but still need to be replayed. Need to use the write set to check.
         if (skippedExecIds.contains(rpTask.execId)) {

--- a/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
@@ -24,7 +24,14 @@ public class PostgresRetroReplay {
     private static final Logger logger = LoggerFactory.getLogger(PostgresRetroReplay.class);
 
     public static Object retroExecuteAll(WorkerContext workerContext, long targetExecID, int replayMode) throws Exception {
-        logger.debug("Replay the entire trace!");
+        if (replayMode == ApiaryConfig.ReplayMode.ALL.getValue()) {
+            logger.debug("Replay the entire trace!");
+        } else if (replayMode == ApiaryConfig.ReplayMode.SELECTIVE.getValue()) {
+            logger.debug("Selective replay!");
+        } else {
+            logger.error("Do not support replay mode: {}", replayMode);
+            return null;
+        }
         assert(workerContext.provBuff != null);
         Connection provConn = workerContext.provBuff.conn.get();
 

--- a/src/main/java/org/dbos/apiary/utilities/ApiaryConfig.java
+++ b/src/main/java/org/dbos/apiary/utilities/ApiaryConfig.java
@@ -42,7 +42,8 @@ public class ApiaryConfig {
     public enum ReplayMode {
         NOT_REPLAY(0),
         SINGLE(1),
-        ALL(2);
+        ALL(2),
+        SELECTIVE(3);
 
         private int value;
 

--- a/src/main/java/org/dbos/apiary/utilities/Utilities.java
+++ b/src/main/java/org/dbos/apiary/utilities/Utilities.java
@@ -3,6 +3,7 @@ package org.dbos.apiary.utilities;
 import com.google.protobuf.ByteString;
 import org.dbos.apiary.ExecuteFunctionReply;
 import org.dbos.apiary.ExecuteFunctionRequest;
+import org.dbos.apiary.function.ApiaryFunction;
 import org.dbos.apiary.function.ProvenanceBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -138,6 +139,11 @@ public class Utilities {
             }
         }
         return null;
+    }
+
+    public static String getFunctionClassName(ApiaryFunction func) {
+        String[] actualNames = func.getClassName().split("\\.");
+        return actualNames[actualNames.length-1];
     }
 
     public static long getMicroTimestamp() {

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -321,7 +321,7 @@ public class ApiaryWorker {
                     // ExecID = 0l means the initial service function, ignore.
                     workerContext.provBuff.addEntry(ApiaryConfig.tableRecordedInputs, execID, req.toByteArray());
                 }
-                if (replayMode == ApiaryConfig.ReplayMode.ALL.getValue()) {
+                if ((replayMode == ApiaryConfig.ReplayMode.ALL.getValue()) || (replayMode == ApiaryConfig.ReplayMode.SELECTIVE.getValue())) {
                     // Must be the first function in a workflow.
                     assert (functionID == 0l);
                     // Retroactive replay mode goes through a separate function.

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -89,6 +89,10 @@ public class ApiaryWorker {
         workerContext.registerFunction(name, type, function);
     }
 
+    public void registerFunction(String name, String type, Callable<ApiaryFunction> function, boolean isRetro) {
+        workerContext.registerFunction(name, type, function, isRetro);
+    }
+
     public void startServing() {
         garbageCollectorThread = new Thread(this::garbageCollectorThread);
         garbageCollectorThread.start();

--- a/src/main/java/org/dbos/apiary/worker/ReplayTask.java
+++ b/src/main/java/org/dbos/apiary/worker/ReplayTask.java
@@ -7,11 +7,13 @@ public class ReplayTask {
     public final long funcId;
     public final String funcName;
     public final Object[] inputs;
+    public final boolean readOnly;
 
-    public ReplayTask(long execId, long funcId, String funcName, Object[] inputs) {
+    public ReplayTask(long execId, long funcId, String funcName, Object[] inputs, boolean readOnly) {
         this.execId = execId;
         this.funcId = funcId;
         this.funcName = funcName;
         this.inputs = inputs;
+        this.readOnly = readOnly;
     }
 }

--- a/src/main/java/org/dbos/apiary/worker/ReplayTask.java
+++ b/src/main/java/org/dbos/apiary/worker/ReplayTask.java
@@ -7,13 +7,11 @@ public class ReplayTask {
     public final long funcId;
     public final String funcName;
     public final Object[] inputs;
-    public final boolean readOnly;
 
-    public ReplayTask(long execId, long funcId, String funcName, Object[] inputs, boolean readOnly) {
+    public ReplayTask(long execId, long funcId, String funcName, Object[] inputs) {
         this.execId = execId;
         this.funcId = funcId;
         this.funcName = funcName;
         this.inputs = inputs;
-        this.readOnly = readOnly;
     }
 }

--- a/src/main/proto/worker.proto
+++ b/src/main/proto/worker.proto
@@ -19,7 +19,7 @@ message ExecuteFunctionRequest {
   int64 senderTimestampNano = 6;
   string service = 7;
   int64 executionId = 8;  // Unique global IDs for an entire workflow.
-  int32 replayMode = 9;  // 0: not replay, 1: replay a single request, 2: replay a request and everything after.
+  int32 replayMode = 9;  // 0: not replay, 1: replay a single request, 2: replay a request and everything after, 3: selective replay.
 }
 
 message ExecuteFunctionReply {

--- a/src/test/java/org/dbos/apiary/MoodleTests.java
+++ b/src/test/java/org/dbos/apiary/MoodleTests.java
@@ -48,8 +48,8 @@ public class MoodleTests {
         // Disable XDB transactions.
         ApiaryConfig.XDBTransactions = false;
 
-        // Disable read tracking.
-        ApiaryConfig.captureReads = false;
+        ApiaryConfig.captureReads = true;
+        ApiaryConfig.captureUpdates = true;
     }
 
     @BeforeEach

--- a/src/test/java/org/dbos/apiary/MoodleTests.java
+++ b/src/test/java/org/dbos/apiary/MoodleTests.java
@@ -8,7 +8,6 @@ import org.dbos.apiary.procedures.postgres.moodle.MDLFetchSubscribers;
 import org.dbos.apiary.procedures.postgres.moodle.MDLForumInsert;
 import org.dbos.apiary.procedures.postgres.moodle.MDLIsSubscribed;
 import org.dbos.apiary.procedures.postgres.moodle.MDLSubscribeTxn;
-import org.dbos.apiary.procedures.postgres.wordpress.WPUtil;
 import org.dbos.apiary.utilities.ApiaryConfig;
 import org.dbos.apiary.utilities.Utilities;
 import org.dbos.apiary.worker.ApiaryNaiveScheduler;
@@ -50,6 +49,7 @@ public class MoodleTests {
 
         ApiaryConfig.captureReads = true;
         ApiaryConfig.captureUpdates = true;
+        ApiaryConfig.recordInput = true;
     }
 
     @BeforeEach
@@ -80,7 +80,7 @@ public class MoodleTests {
     @Test
     public void testForumSubscribeReplay() throws SQLException, InvalidProtocolBufferException, InterruptedException {
         logger.info("testForumSubscribeReplay");
-        PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, "postgres", "dbos");
+        PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, ApiaryConfig.postgres, "dbos");
 
         apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
         apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);

--- a/src/test/java/org/dbos/apiary/MoodleTests.java
+++ b/src/test/java/org/dbos/apiary/MoodleTests.java
@@ -75,6 +75,8 @@ public class MoodleTests {
         if (apiaryWorker != null) {
             apiaryWorker.shutdown();
         }
+        // Reset flags.
+        ApiaryConfig.recordInput = false;
     }
 
     @Test

--- a/src/test/java/org/dbos/apiary/MoodleTests.java
+++ b/src/test/java/org/dbos/apiary/MoodleTests.java
@@ -337,5 +337,12 @@ public class MoodleTests {
         int[] retroList = client.get().retroReplay(resExecId, ApiaryConfig.ReplayMode.ALL.getValue()).getIntArray();
         assertEquals(1, retroList.length);
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
+
+        // Retro replay again, but now we enable selective replay.
+        conn.truncateTable("ForumSubscription", false);
+        // TODO: what is a better stop strategy?
+        int retroRes = client.get().retroReplay(resExecId, ApiaryConfig.ReplayMode.SELECTIVE.getValue()).getInt();
+        assertTrue(retroRes != -1);
+        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
     }
 }

--- a/src/test/java/org/dbos/apiary/MoodleTests.java
+++ b/src/test/java/org/dbos/apiary/MoodleTests.java
@@ -12,10 +12,7 @@ import org.dbos.apiary.utilities.ApiaryConfig;
 import org.dbos.apiary.utilities.Utilities;
 import org.dbos.apiary.worker.ApiaryNaiveScheduler;
 import org.dbos.apiary.worker.ApiaryWorker;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +72,10 @@ public class MoodleTests {
         if (apiaryWorker != null) {
             apiaryWorker.shutdown();
         }
-        // Reset flags.
+    }
+
+    @AfterAll
+    public static void resetFlags() {
         ApiaryConfig.recordInput = false;
     }
 

--- a/src/test/java/org/dbos/apiary/MoodleTests.java
+++ b/src/test/java/org/dbos/apiary/MoodleTests.java
@@ -1,0 +1,341 @@
+package org.dbos.apiary;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.dbos.apiary.client.ApiaryWorkerClient;
+import org.dbos.apiary.function.ProvenanceBuffer;
+import org.dbos.apiary.postgres.PostgresConnection;
+import org.dbos.apiary.procedures.postgres.moodle.MDLFetchSubscribers;
+import org.dbos.apiary.procedures.postgres.moodle.MDLForumInsert;
+import org.dbos.apiary.procedures.postgres.moodle.MDLIsSubscribed;
+import org.dbos.apiary.procedures.postgres.moodle.MDLSubscribeTxn;
+import org.dbos.apiary.procedures.postgres.wordpress.WPUtil;
+import org.dbos.apiary.utilities.ApiaryConfig;
+import org.dbos.apiary.utilities.Utilities;
+import org.dbos.apiary.worker.ApiaryNaiveScheduler;
+import org.dbos.apiary.worker.ApiaryWorker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+// To test the bug and fixes of Moodle bugs. Moodle 59854, 28949, 43421.
+public class MoodleTests {
+    private static final Logger logger = LoggerFactory.getLogger(MoodleTests.class);
+
+    private ApiaryWorker apiaryWorker;
+
+    @BeforeAll
+    public static void testConnection() {
+        assumeTrue(TestUtils.testPostgresConnection());
+        // Set the isolation level to serializable.
+        ApiaryConfig.isolationLevel = ApiaryConfig.SERIALIZABLE;
+
+        // Disable XDB transactions.
+        ApiaryConfig.XDBTransactions = false;
+
+        // Disable read tracking.
+        ApiaryConfig.captureReads = false;
+    }
+
+    @BeforeEach
+    public void resetTables() {
+        try {
+            PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, ApiaryConfig.postgres, "dbos");
+            conn.dropTable(ApiaryConfig.tableFuncInvocations);
+            conn.dropTable(ApiaryConfig.tableRecordedInputs);
+            conn.dropTable(ProvenanceBuffer.PROV_ApiaryMetadata);
+            conn.dropTable(ProvenanceBuffer.PROV_QueryMetadata);
+            conn.dropTable("ForumSubscription");
+            conn.createTable("ForumSubscription", "UserId integer NOT NULL, ForumId integer NOT NULL");
+        } catch (Exception e) {
+            e.printStackTrace();
+            logger.info("Failed to connect to Postgres.");
+            assumeTrue(false);
+        }
+        apiaryWorker = null;
+    }
+
+    @AfterEach
+    public void cleanupWorker() {
+        if (apiaryWorker != null) {
+            apiaryWorker.shutdown();
+        }
+    }
+
+    @Test
+    public void testForumSubscribeReplay() throws SQLException, InvalidProtocolBufferException, InterruptedException {
+        logger.info("testForumSubscribeReplay");
+        PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, "postgres", "dbos");
+
+        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
+        apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);
+        apiaryWorker.registerFunction("MDLIsSubscribed", ApiaryConfig.postgres, MDLIsSubscribed::new);
+        apiaryWorker.registerFunction("MDLForumInsert", ApiaryConfig.postgres, MDLForumInsert::new);
+        apiaryWorker.registerFunction("MDLFetchSubscribers", ApiaryConfig.postgres, MDLFetchSubscribers::new);
+        apiaryWorker.startServing();
+
+        ProvenanceBuffer provBuff = apiaryWorker.workerContext.provBuff;
+        assert(provBuff != null);
+
+        ApiaryWorkerClient client = new ApiaryWorkerClient("localhost");
+
+        int res;
+        res = client.executeFunction("MDLIsSubscribed", 123, 555).getInt();
+        assertEquals(123, res);
+
+        // Subscribe again, should return the same userId.
+        res = client.executeFunction("MDLIsSubscribed", 123, 555).getInt();
+        assertEquals(123, res);
+
+        // Get a list of subscribers, should only contain one user entry.
+        int[] resList = client.executeFunction("MDLFetchSubscribers",555).getIntArray();
+        assertEquals(1, resList.length);
+        assertEquals(123, resList[0]);
+
+        // Check provenance and get executionID.
+        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
+        Connection provConn = provBuff.conn.get();
+        Statement stmt = provConn.createStatement();
+
+        String table = ApiaryConfig.tableFuncInvocations;
+        ResultSet rs = stmt.executeQuery(String.format("SELECT * FROM %s ORDER BY %s ASC;", table, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID));
+        rs.next();
+        long resExecId = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
+        long resFuncId = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
+        String resFuncName = rs.getString(ProvenanceBuffer.PROV_PROCEDURENAME);
+        assertTrue(resExecId >= 0);
+        assertEquals("MDLIsSubscribed", resFuncName);
+
+        // The second function should be a subscribe function.
+        rs.next();
+        long resExecId2 = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
+        long resFuncId2 = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
+        assertEquals(resExecId, resExecId2);
+
+        // The third function should be a new execution.
+        rs.next();
+        long resExecId3 = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
+        long resFuncId3 = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
+        assertNotEquals(resExecId, resExecId3);
+        assertEquals(resFuncId, resFuncId3);
+
+        // The fourth function should be a new fetchSubscribers.
+        rs.next();
+        long resExecId4 = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
+        long resFuncId4 = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
+        assertNotEquals(resExecId, resExecId4);
+        assertNotEquals(resExecId3, resExecId4);
+        assertEquals(resFuncId, resFuncId4);
+
+        // Replay the execution of the first one.
+        res = client.replayFunction(resExecId,"MDLIsSubscribed", 123, 555).getInt();
+        assertEquals(123, res);
+
+        // Check provenance.
+        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
+        String provQuery = String.format("SELECT * FROM %s ORDER BY %s DESC;", table, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
+        // Check the replay record.
+        rs = stmt.executeQuery(provQuery);
+        rs.next();
+        // The reversed first one should be the replay of an insert.
+        long replayExecId = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
+        long replayFuncId = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
+        short resIsReplay = rs.getShort(ProvenanceBuffer.PROV_ISREPLAY);
+        assertEquals(resExecId, replayExecId);
+        assertEquals(resFuncId2, replayFuncId);
+        assertEquals(1, resIsReplay);
+
+        // Replay the next execution. Which should skip the subscribe function.
+        res = client.replayFunction(resExecId3, "MDLIsSubscribed", 123, 555).getInt();
+        assertEquals(123, res);
+        rs.close();
+
+        // Check provenance data again.
+        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
+        rs = stmt.executeQuery(provQuery);
+        rs.next();
+        // The reversed first one should be the isSubscribed function.
+        replayExecId = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
+        replayFuncId = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
+        resIsReplay = rs.getShort(ProvenanceBuffer.PROV_ISREPLAY);
+        assertEquals(resExecId3, replayExecId);
+        assertEquals(resFuncId3, replayFuncId);
+        assertEquals(1, resIsReplay);
+
+        // Check the recorded inputs.
+        table = ApiaryConfig.tableRecordedInputs;
+        provQuery = String.format("SELECT * FROM %s ORDER BY %s ASC;", table, ProvenanceBuffer.PROV_EXECUTIONID);
+        rs = stmt.executeQuery(provQuery);
+        rs.next();
+
+        // The order should be the same.
+        long recordExecid = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
+        byte[] recordInput = rs.getBytes(ProvenanceBuffer.PROV_REQ_BYTES);
+        ExecuteFunctionRequest req = ExecuteFunctionRequest.parseFrom(recordInput);
+        Object[] arguments = Utilities.getArgumentsFromRequest(req);
+        assertEquals(resExecId, recordExecid);
+        assertEquals(resExecId, req.getExecutionId());
+        assertEquals(2, arguments.length);
+        assertEquals(123, (int) arguments[0]);
+        assertEquals(555, (int) arguments[1]);
+
+        rs.next();
+        recordExecid = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
+        recordInput = rs.getBytes(ProvenanceBuffer.PROV_REQ_BYTES);
+        req = ExecuteFunctionRequest.parseFrom(recordInput);
+        arguments = Utilities.getArgumentsFromRequest(req);
+        assertEquals(resExecId3, recordExecid);
+        assertEquals(resExecId3, req.getExecutionId());
+        assertEquals(2, arguments.length);
+        assertEquals(123, (int) arguments[0]);
+        assertEquals(555, (int) arguments[1]);
+
+        rs.next();
+        recordExecid = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
+        recordInput = rs.getBytes(ProvenanceBuffer.PROV_REQ_BYTES);
+        req = ExecuteFunctionRequest.parseFrom(recordInput);
+        arguments = Utilities.getArgumentsFromRequest(req);
+        assertEquals(resExecId4, recordExecid);
+        assertEquals(resExecId4, req.getExecutionId());
+        assertEquals(1, arguments.length);
+        assertEquals(555, (int) arguments[0]);
+        rs.close();
+
+        // Retroactively execute all.
+        // Reset the database and re-execute.
+        conn.truncateTable("ForumSubscription", false);
+        resList = client.retroReplay(resExecId, ApiaryConfig.ReplayMode.ALL.getValue()).getIntArray();
+        assertEquals(1, resList.length);
+        assertEquals(123, resList[0]);
+        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
+    }
+
+    @Test
+    public void testForumSubscribeRetro() throws SQLException, InterruptedException, InvalidProtocolBufferException, ExecutionException {
+        logger.info("testForumSubscribeRetro");
+
+        // Run concurrent test until we find duplications. Then retroactively replay everything.
+        PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, "postgres", "dbos");
+
+        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
+        apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);
+        apiaryWorker.registerFunction("MDLIsSubscribed", ApiaryConfig.postgres, MDLIsSubscribed::new);
+        apiaryWorker.registerFunction("MDLForumInsert", ApiaryConfig.postgres, MDLForumInsert::new);
+        apiaryWorker.registerFunction("MDLFetchSubscribers", ApiaryConfig.postgres, MDLFetchSubscribers::new);
+        apiaryWorker.startServing();
+
+        ProvenanceBuffer provBuff = apiaryWorker.workerContext.provBuff;
+        assert(provBuff != null);
+
+        ThreadLocal<ApiaryWorkerClient> client = ThreadLocal.withInitial(() -> new ApiaryWorkerClient("localhost"));
+
+        // Start a thread pool.
+        ExecutorService threadPool = Executors.newFixedThreadPool(2);
+
+        class SubsTask implements Callable<Integer> {
+            private final int userId;
+            private final int forumId;
+
+            public SubsTask(int userId, int forumId) {
+                this.userId = userId;
+                this.forumId = forumId;
+            }
+
+            @Override
+            public Integer call() {
+                int res;
+                try {
+                    res = client.get().executeFunction("MDLIsSubscribed", userId, forumId).getInt();
+                } catch (Exception e) {
+                    res = -1;
+                }
+                return res;
+            }
+        }
+
+        // Try many times until we find duplications.
+        int maxTry = 1000;
+        int[] resList = null;
+        for (int i = 0; i < maxTry; i++) {
+            // Push two concurrent tasks.
+            List<SubsTask> tasks = new ArrayList<>();
+            tasks.add(new SubsTask(i, i+maxTry));
+            tasks.add(new SubsTask(i, i+maxTry));
+            List<Future<Integer>> futures = threadPool.invokeAll(tasks);
+            for (Future<Integer> future : futures) {
+                if (!future.isCancelled()) {
+                    int res = future.get();
+                    assertTrue(res != -1);
+                }
+            }
+            // Check subscriptions.
+            resList = client.get().executeFunction("MDLFetchSubscribers", i+maxTry).getIntArray();
+            if (resList.length > 1) {
+                logger.info("Found duplications! User: {}, Forum: {}", i, i+maxTry);
+                break;
+            }
+        }
+
+        // Only continue the test if we have found duplications.
+        if (resList == null || resList.length == 1) {
+            logger.warn("Did not find duplicates. Skip test");
+        }
+        assumeTrue(resList.length > 1);
+        threadPool.shutdown();
+
+        // Wait for provenance to be exported.
+        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
+
+        // Check the original execution.
+        Connection provConn = provBuff.conn.get();
+        Statement stmt = provConn.createStatement();
+        String provQuery = String.format("SELECT * FROM %s ORDER BY %s ASC;", ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
+        ResultSet rs = stmt.executeQuery(provQuery);
+        rs.next();
+        long resExecId = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
+        long resFuncId = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
+        String resFuncName = rs.getString(ProvenanceBuffer.PROV_PROCEDURENAME);
+        assertTrue(resExecId >= 0);
+        assumeTrue(resFuncId == 0);
+        assertEquals("MDLIsSubscribed", resFuncName);
+
+        // Reset the table and replay all.
+        conn.truncateTable("ForumSubscription", false);
+        int[] retroResList = client.get().retroReplay(resExecId, ApiaryConfig.ReplayMode.ALL.getValue()).getIntArray();
+        assertEquals(resList.length, retroResList.length);
+        assertTrue(Arrays.equals(resList, retroResList));
+        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
+
+        // Now, register the new code and see if it can get the correct result.
+        apiaryWorker.shutdown(); // Stop the existing worker.
+        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
+        apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);
+        apiaryWorker.registerFunction("MDLIsSubscribed", ApiaryConfig.postgres, MDLSubscribeTxn::new, true);  // Register the new one.
+        // Do not register the second subscribe function.
+        apiaryWorker.registerFunction("MDLFetchSubscribers", ApiaryConfig.postgres, MDLFetchSubscribers::new);
+        apiaryWorker.startServing();
+
+        provBuff = apiaryWorker.workerContext.provBuff;
+        assert(provBuff != null);
+
+        conn.truncateTable("ForumSubscription", false);
+        int[] retroList = client.get().retroReplay(resExecId, ApiaryConfig.ReplayMode.ALL.getValue()).getIntArray();
+        assertEquals(1, retroList.length);
+        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
+    }
+}

--- a/src/test/java/org/dbos/apiary/ProvenanceTests.java
+++ b/src/test/java/org/dbos/apiary/ProvenanceTests.java
@@ -4,15 +4,10 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.dbos.apiary.client.ApiaryWorkerClient;
 import org.dbos.apiary.function.ProvenanceBuffer;
 import org.dbos.apiary.postgres.PostgresConnection;
-import org.dbos.apiary.procedures.postgres.moodle.MDLFetchSubscribers;
-import org.dbos.apiary.procedures.postgres.moodle.MDLForumInsert;
-import org.dbos.apiary.procedures.postgres.moodle.MDLIsSubscribed;
-import org.dbos.apiary.procedures.postgres.moodle.MDLSubscribeTxn;
 import org.dbos.apiary.procedures.postgres.tests.PostgresProvenanceBasic;
 import org.dbos.apiary.procedures.postgres.tests.PostgresProvenanceJoins;
 import org.dbos.apiary.procedures.postgres.tests.PostgresProvenanceMultiRows;
 import org.dbos.apiary.utilities.ApiaryConfig;
-import org.dbos.apiary.utilities.Utilities;
 import org.dbos.apiary.worker.ApiaryNaiveScheduler;
 import org.dbos.apiary.worker.ApiaryWorker;
 import org.junit.jupiter.api.AfterEach;
@@ -26,13 +21,8 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.*;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.jupiter.api.Assumptions.assumeFalse;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class ProvenanceTests {
@@ -65,8 +55,6 @@ public class ProvenanceTests {
             conn.createTable("KVTable", "KVKey integer PRIMARY KEY NOT NULL, KVValue integer NOT NULL");
             conn.dropTable("KVTableTwo");
             conn.createTable("KVTableTwo", "KVKeyTwo integer PRIMARY KEY NOT NULL, KVValueTwo integer NOT NULL");
-            conn.dropTable("ForumSubscription");
-            conn.createTable("ForumSubscription", "UserId integer NOT NULL, ForumId integer NOT NULL");
         } catch (Exception e) {
             e.printStackTrace();
             logger.info("Failed to connect to Postgres.");
@@ -81,269 +69,6 @@ public class ProvenanceTests {
             apiaryWorker.shutdown();
         }
     }
-
-    @Test
-    public void testForumSubscribeReplay() throws SQLException, InvalidProtocolBufferException, InterruptedException {
-        logger.info("testForumSubscribeReplay");
-        PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, "postgres", "dbos");
-
-        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
-        apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);
-        apiaryWorker.registerFunction("MDLIsSubscribed", ApiaryConfig.postgres, MDLIsSubscribed::new);
-        apiaryWorker.registerFunction("MDLForumInsert", ApiaryConfig.postgres, MDLForumInsert::new);
-        apiaryWorker.registerFunction("MDLFetchSubscribers", ApiaryConfig.postgres, MDLFetchSubscribers::new);
-        apiaryWorker.startServing();
-
-        ProvenanceBuffer provBuff = apiaryWorker.workerContext.provBuff;
-        assert(provBuff != null);
-
-        ApiaryWorkerClient client = new ApiaryWorkerClient("localhost");
-
-        int res;
-        res = client.executeFunction("MDLIsSubscribed", 123, 555).getInt();
-        assertEquals(123, res);
-
-        // Subscribe again, should return the same userId.
-        res = client.executeFunction("MDLIsSubscribed", 123, 555).getInt();
-        assertEquals(123, res);
-
-        // Get a list of subscribers, should only contain one user entry.
-        int[] resList = client.executeFunction("MDLFetchSubscribers",555).getIntArray();
-        assertEquals(1, resList.length);
-        assertEquals(123, resList[0]);
-
-        // Check provenance and get executionID.
-        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
-        Connection provConn = provBuff.conn.get();
-        Statement stmt = provConn.createStatement();
-
-        String table = ApiaryConfig.tableFuncInvocations;
-        ResultSet rs = stmt.executeQuery(String.format("SELECT * FROM %s ORDER BY %s ASC;", table, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID));
-        rs.next();
-        long resExecId = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
-        long resFuncId = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
-        String resFuncName = rs.getString(ProvenanceBuffer.PROV_PROCEDURENAME);
-        assertTrue(resExecId >= 0);
-        assertEquals("MDLIsSubscribed", resFuncName);
-
-        // The second function should be a subscribe function.
-        rs.next();
-        long resExecId2 = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
-        long resFuncId2 = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
-        assertEquals(resExecId, resExecId2);
-
-        // The third function should be a new execution.
-        rs.next();
-        long resExecId3 = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
-        long resFuncId3 = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
-        assertNotEquals(resExecId, resExecId3);
-        assertEquals(resFuncId, resFuncId3);
-
-        // The fourth function should be a new fetchSubscribers.
-        rs.next();
-        long resExecId4 = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
-        long resFuncId4 = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
-        assertNotEquals(resExecId, resExecId4);
-        assertNotEquals(resExecId3, resExecId4);
-        assertEquals(resFuncId, resFuncId4);
-
-        // Replay the execution of the first one.
-        res = client.replayFunction(resExecId,"MDLIsSubscribed", 123, 555).getInt();
-        assertEquals(123, res);
-
-        // Check provenance.
-        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
-        String provQuery = String.format("SELECT * FROM %s ORDER BY %s DESC;", table, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
-        // Check the replay record.
-        rs = stmt.executeQuery(provQuery);
-        rs.next();
-        // The reversed first one should be the replay of an insert.
-        long replayExecId = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
-        long replayFuncId = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
-        short resIsReplay = rs.getShort(ProvenanceBuffer.PROV_ISREPLAY);
-        assertEquals(resExecId, replayExecId);
-        assertEquals(resFuncId2, replayFuncId);
-        assertEquals(1, resIsReplay);
-
-        // Replay the next execution. Which should skip the subscribe function.
-        res = client.replayFunction(resExecId3, "MDLIsSubscribed", 123, 555).getInt();
-        assertEquals(123, res);
-        rs.close();
-
-        // Check provenance data again.
-        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
-        rs = stmt.executeQuery(provQuery);
-        rs.next();
-        // The reversed first one should be the isSubscribed function.
-        replayExecId = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
-        replayFuncId = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
-        resIsReplay = rs.getShort(ProvenanceBuffer.PROV_ISREPLAY);
-        assertEquals(resExecId3, replayExecId);
-        assertEquals(resFuncId3, replayFuncId);
-        assertEquals(1, resIsReplay);
-
-        // Check the recorded inputs.
-        table = ApiaryConfig.tableRecordedInputs;
-        provQuery = String.format("SELECT * FROM %s ORDER BY %s ASC;", table, ProvenanceBuffer.PROV_EXECUTIONID);
-        rs = stmt.executeQuery(provQuery);
-        rs.next();
-
-        // The order should be the same.
-        long recordExecid = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
-        byte[] recordInput = rs.getBytes(ProvenanceBuffer.PROV_REQ_BYTES);
-        ExecuteFunctionRequest req = ExecuteFunctionRequest.parseFrom(recordInput);
-        Object[] arguments = Utilities.getArgumentsFromRequest(req);
-        assertEquals(resExecId, recordExecid);
-        assertEquals(resExecId, req.getExecutionId());
-        assertEquals(2, arguments.length);
-        assertEquals(123, (int) arguments[0]);
-        assertEquals(555, (int) arguments[1]);
-
-        rs.next();
-        recordExecid = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
-        recordInput = rs.getBytes(ProvenanceBuffer.PROV_REQ_BYTES);
-        req = ExecuteFunctionRequest.parseFrom(recordInput);
-        arguments = Utilities.getArgumentsFromRequest(req);
-        assertEquals(resExecId3, recordExecid);
-        assertEquals(resExecId3, req.getExecutionId());
-        assertEquals(2, arguments.length);
-        assertEquals(123, (int) arguments[0]);
-        assertEquals(555, (int) arguments[1]);
-
-        rs.next();
-        recordExecid = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
-        recordInput = rs.getBytes(ProvenanceBuffer.PROV_REQ_BYTES);
-        req = ExecuteFunctionRequest.parseFrom(recordInput);
-        arguments = Utilities.getArgumentsFromRequest(req);
-        assertEquals(resExecId4, recordExecid);
-        assertEquals(resExecId4, req.getExecutionId());
-        assertEquals(1, arguments.length);
-        assertEquals(555, (int) arguments[0]);
-        rs.close();
-
-        // Retroactively execute all.
-        // Reset the database and re-execute.
-        conn.truncateTable("ForumSubscription", false);
-        resList = client.retroReplay(resExecId).getIntArray();
-        assertEquals(1, resList.length);
-        assertEquals(123, resList[0]);
-        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
-    }
-
-    @Test
-    public void testForumSubscribeRetro() throws SQLException, InterruptedException, InvalidProtocolBufferException, ExecutionException {
-        logger.info("testForumSubscribeRetro");
-
-        // Run concurrent test until we find duplications. Then retroactively replay everything.
-        PostgresConnection conn = new PostgresConnection("localhost", ApiaryConfig.postgresPort, "postgres", "dbos");
-
-        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
-        apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);
-        apiaryWorker.registerFunction("MDLIsSubscribed", ApiaryConfig.postgres, MDLIsSubscribed::new);
-        apiaryWorker.registerFunction("MDLForumInsert", ApiaryConfig.postgres, MDLForumInsert::new);
-        apiaryWorker.registerFunction("MDLFetchSubscribers", ApiaryConfig.postgres, MDLFetchSubscribers::new);
-        apiaryWorker.startServing();
-
-        ProvenanceBuffer provBuff = apiaryWorker.workerContext.provBuff;
-        assert(provBuff != null);
-
-        ThreadLocal<ApiaryWorkerClient> client = ThreadLocal.withInitial(() -> new ApiaryWorkerClient("localhost"));
-
-        // Start a thread pool.
-        ExecutorService threadPool = Executors.newFixedThreadPool(2);
-
-        class SubsTask implements Callable<Integer> {
-            private final int userId;
-            private final int forumId;
-
-            public SubsTask(int userId, int forumId) {
-                this.userId = userId;
-                this.forumId = forumId;
-            }
-
-            @Override
-            public Integer call() {
-                int res;
-                try {
-                    res = client.get().executeFunction("MDLIsSubscribed", userId, forumId).getInt();
-                } catch (Exception e) {
-                    res = -1;
-                }
-                return res;
-            }
-        }
-
-        // Try many times until we find duplications.
-        int maxTry = 1000;
-        int[] resList = null;
-        for (int i = 0; i < maxTry; i++) {
-            // Push two concurrent tasks.
-            List<SubsTask> tasks = new ArrayList<>();
-            tasks.add(new SubsTask(i, i+maxTry));
-            tasks.add(new SubsTask(i, i+maxTry));
-            List<Future<Integer>> futures = threadPool.invokeAll(tasks);
-            for (Future<Integer> future : futures) {
-                if (!future.isCancelled()) {
-                    int res = future.get();
-                    assertTrue(res != -1);
-                }
-            }
-            // Check subscriptions.
-            resList = client.get().executeFunction("MDLFetchSubscribers", i+maxTry).getIntArray();
-            if (resList.length > 1) {
-                logger.info("Found duplications! User: {}, Forum: {}", i, i+maxTry);
-                break;
-            }
-        }
-
-        // Only continue the test if we have found duplications.
-        if (resList == null || resList.length == 1) {
-            logger.warn("Did not find duplicates. Skip test");
-        }
-        assumeTrue(resList.length > 1);
-        threadPool.shutdown();
-
-        // Wait for provenance to be exported.
-        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
-
-        // Check the original execution.
-        Connection provConn = provBuff.conn.get();
-        Statement stmt = provConn.createStatement();
-        String provQuery = String.format("SELECT * FROM %s ORDER BY %s ASC;", ApiaryConfig.tableFuncInvocations, ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
-        ResultSet rs = stmt.executeQuery(provQuery);
-        rs.next();
-        long resExecId = rs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
-        long resFuncId = rs.getLong(ProvenanceBuffer.PROV_FUNCID);
-        String resFuncName = rs.getString(ProvenanceBuffer.PROV_PROCEDURENAME);
-        assertTrue(resExecId >= 0);
-        assumeTrue(resFuncId == 0);
-        assertEquals("MDLIsSubscribed", resFuncName);
-
-        // Reset the table and replay all.
-        conn.truncateTable("ForumSubscription", false);
-        int[] retroResList = client.get().retroReplay(resExecId).getIntArray();
-        assertEquals(resList.length, retroResList.length);
-        assertTrue(Arrays.equals(resList, retroResList));
-        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
-
-        // Now, register the new code and see if it can get the correct result.
-        apiaryWorker.shutdown(); // Stop the existing worker.
-        apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
-        apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);
-        apiaryWorker.registerFunction("MDLIsSubscribed", ApiaryConfig.postgres, MDLSubscribeTxn::new);  // Register the new one.
-        // Do not register the second subscribe function.
-        apiaryWorker.registerFunction("MDLFetchSubscribers", ApiaryConfig.postgres, MDLFetchSubscribers::new);
-        apiaryWorker.startServing();
-
-        provBuff = apiaryWorker.workerContext.provBuff;
-        assert(provBuff != null);
-
-        conn.truncateTable("ForumSubscription", false);
-        int[] retroList = client.get().retroReplay(resExecId).getIntArray();
-        assertEquals(1, retroList.length);
-        Thread.sleep(ProvenanceBuffer.exportInterval * 2);
-    }
-
 
     @Test
     public void testProvenanceBuffer() throws InterruptedException, ClassNotFoundException, SQLException {

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -204,7 +204,7 @@ public class WordPressTests {
             Future<Integer> trashResFut = threadPool.submit(new WpTask(postIds, -1, "trashpost"));
             // Add arbitrary delay.
             Thread.sleep(ThreadLocalRandom.current().nextInt(5));
-            Future<Integer> commentResFut = threadPool.submit(new WpTask(postIds, commentIds, "test comment to a post " + commentIds));
+            Future<Integer> commentResFut = threadPool.submit(new WpTask(postIds, commentIds, "test comment " + commentIds));
 
             int trashRes, commentRes;
             try {
@@ -221,7 +221,7 @@ public class WordPressTests {
             assertEquals(0, intRes);
 
             String[] resList = client.get().executeFunction("WPGetPostComments", postIds).getStringArray();
-            assertEquals(2, resList.length);
+            assertTrue(resList.length > 1);
 
             // Check results. Try to find inconsistency.
             strAryRes = client.get().executeFunction("WPCheckCommentStatus", postIds).getStringArray();

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -254,7 +254,7 @@ public class WordPressTests {
         conn.truncateTable(WPUtil.WP_COMMENTS_TABLE, false);
         conn.truncateTable(WPUtil.WP_POSTMETA_TABLE, false);
 
-        strAryRes = client.get().retroReplay(resExecId).getStringArray();
+        strAryRes = client.get().retroReplay(resExecId, ApiaryConfig.ReplayMode.ALL.getValue()).getStringArray();
         assertTrue(strAryRes.length > 1);
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
 
@@ -264,7 +264,7 @@ public class WordPressTests {
         apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);
         apiaryWorker.registerFunction("WPAddPost", ApiaryConfig.postgres, WPAddPost::new);
         // Use the new code.
-        apiaryWorker.registerFunction("WPAddComment", ApiaryConfig.postgres, WPAddCommentFixed::new);
+        apiaryWorker.registerFunction("WPAddComment", ApiaryConfig.postgres, WPAddCommentFixed::new, true);
         apiaryWorker.registerFunction("WPGetPostComments", ApiaryConfig.postgres, WPGetPostComments::new);
         apiaryWorker.registerFunction("WPTrashPost", ApiaryConfig.postgres, WPTrashPost::new);
         apiaryWorker.registerFunction("WPTrashComments", ApiaryConfig.postgres, WPTrashComments::new);
@@ -279,7 +279,7 @@ public class WordPressTests {
         conn.truncateTable(WPUtil.WP_COMMENTS_TABLE, false);
         conn.truncateTable(WPUtil.WP_POSTMETA_TABLE, false);
 
-        strAryRes = client.get().retroReplay(resExecId).getStringArray();
+        strAryRes = client.get().retroReplay(resExecId, ApiaryConfig.ReplayMode.ALL.getValue()).getStringArray();
         assertEquals(1, strAryRes.length);
 
         ApiaryConfig.recordInput = false; // Reset flags.

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -196,7 +196,7 @@ public class WordPressTests {
             // Add a new post and a comment.
             intRes = client.get().executeFunction("WPAddPost", postIds, "test post " + postIds).getInt();
             assertEquals(0, intRes);
-            intRes = client.get().executeFunction("WPAddComment", postIds, commentIds, "test comment to a post " + commentIds).getInt();
+            intRes = client.get().executeFunction("WPAddComment", postIds, commentIds, "test comment " + commentIds).getInt();
             commentIds++;
             assertEquals(0, intRes);
 
@@ -204,7 +204,7 @@ public class WordPressTests {
             Future<Integer> trashResFut = threadPool.submit(new WpTask(postIds, -1, "trashpost"));
             // Add arbitrary delay.
             Thread.sleep(ThreadLocalRandom.current().nextInt(5));
-            Future<Integer> commentResFut = threadPool.submit(new WpTask(postIds, commentIds, "test comment " + commentIds));
+            Future<Integer> commentResFut = threadPool.submit(new WpTask(postIds, commentIds, "test comment concurrent " + commentIds));
 
             int trashRes, commentRes;
             try {
@@ -269,9 +269,9 @@ public class WordPressTests {
         // Use the new code.
         apiaryWorker.registerFunction("WPAddComment", ApiaryConfig.postgres, WPAddCommentFixed::new, true);
         apiaryWorker.registerFunction("WPGetPostComments", ApiaryConfig.postgres, WPGetPostComments::new);
-        apiaryWorker.registerFunction("WPTrashPost", ApiaryConfig.postgres, WPTrashPost::new, true);
-        apiaryWorker.registerFunction("WPTrashComments", ApiaryConfig.postgres, WPTrashComments::new, true);
-        apiaryWorker.registerFunction("WPUntrashPost", ApiaryConfig.postgres, WPUntrashPost::new, true);
+        apiaryWorker.registerFunction("WPTrashPost", ApiaryConfig.postgres, WPTrashPost::new);
+        apiaryWorker.registerFunction("WPTrashComments", ApiaryConfig.postgres, WPTrashComments::new);
+        apiaryWorker.registerFunction("WPUntrashPost", ApiaryConfig.postgres, WPUntrashPost::new);
         apiaryWorker.registerFunction("WPCheckCommentStatus", ApiaryConfig.postgres, WPCheckCommentStatus::new);
         apiaryWorker.startServing();
 


### PR DESCRIPTION
This PR implements a basic selective retro replay mode. During replay, it skips based on a few heuristics:

1) Check at the first function of each request. If the first function has been skipped, then all downstream functions will be skipped.
2) If a function name is in the list of retroFunctions (modified functions), then we cannot skip.
3) Cannot skip a request if any of its functions contains writes and reads/writes the write set (we track which tables have been modified since replay).

Also refactored the Moodle tests to a new file.