### PR TITLE
Retro End Condition

### DIFF
--- a/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
+++ b/src/main/java/org/dbos/apiary/benchmarks/RetroBenchmark.java
@@ -217,7 +217,7 @@ public class RetroBenchmark {
             int res = client.get().replayFunction(targetExecId, "MDLIsSubscribed", initialUserId, initialForumId).getInt();
             assert (res == initialUserId);
         } else if (replayMode == ApiaryConfig.ReplayMode.ALL.getValue()){
-            FunctionOutput res = client.get().retroReplay(targetExecId, ApiaryConfig.ReplayMode.ALL.getValue());
+            FunctionOutput res = client.get().retroReplay(targetExecId, Long.MAX_VALUE, ApiaryConfig.ReplayMode.ALL.getValue());
             assert (res != null);
         } else {
             logger.error("Do not support replay mode {}", replayMode);

--- a/src/main/java/org/dbos/apiary/client/ApiaryWorkerClient.java
+++ b/src/main/java/org/dbos/apiary/client/ApiaryWorkerClient.java
@@ -96,7 +96,8 @@ public class ApiaryWorkerClient {
     /**
      * Replay the execution and everything after it using the original execution trace. Block waiting for the result of the last execution. The replay will not generate new provenance data.
      *
-     * @param execId    the original execution ID of the target request.
+     * @param startExecId    the original execution ID of the target request.
+     * @param endExecId the execution ID of a request past the last request of the replay, excluded from replay.
      * @param retroMode the mode of replay. See {@link ApiaryConfig.ReplayMode}
      * @return the output of the last execution.
      * @throws InvalidProtocolBufferException

--- a/src/main/java/org/dbos/apiary/client/ApiaryWorkerClient.java
+++ b/src/main/java/org/dbos/apiary/client/ApiaryWorkerClient.java
@@ -101,8 +101,8 @@ public class ApiaryWorkerClient {
      * @return the output of the last execution.
      * @throws InvalidProtocolBufferException
      */
-    public FunctionOutput retroReplay(long execId, int retroMode) throws InvalidProtocolBufferException {
-        return internalClient.executeFunction(this.apiaryWorkerAddress, "retroReplay", "DefaultService", execId, retroMode, null);
+    public FunctionOutput retroReplay(long startExecId, long endExecId, int retroMode) throws InvalidProtocolBufferException {
+        return internalClient.retroReplay(this.apiaryWorkerAddress, "retroReplay", "DefaultService", startExecId, endExecId, retroMode, null);
     }
 
     /**

--- a/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
@@ -139,16 +139,13 @@ public class PostgresRetroReplay {
         // A map storing the task info for a pending commit transaction. GC after the task is committed.
         Map<Long, ReplayTask> pendingCommitTask = new HashMap<>();
 
-        // Current transaction ID, execution ID, and function ID.
-        long resTxId = -1, resExecId = -1, resFuncId = -1;
-
-        while ((nextCommitTxid > 0) && (resTxId < endTxId)) {
+        while ((nextCommitTxid > 0) && (nextCommitTxid < endTxId)) {
             // Execute all following functions until nextCommitTxid is in the snapshot of that original transaction.
             // If the nextCommitTxid is in the snapshot, then that function needs to start after it commits.
             while (true) {
-                resTxId = startOrderRs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
-                resExecId = startOrderRs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
-                resFuncId = startOrderRs.getLong(ProvenanceBuffer.PROV_FUNCID);
+                long resTxId = startOrderRs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
+                long resExecId = startOrderRs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
+                long resFuncId = startOrderRs.getLong(ProvenanceBuffer.PROV_FUNCID);
 
                 if (resTxId >= endTxId) {
                     // Stop at the last transaction Id.

--- a/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
@@ -53,7 +53,8 @@ public class PostgresRetroReplay {
         }
         historyRs.close();
 
-        // Find the transaction ID of the last transaction. Only need to find the first function.
+        // Find the transaction ID of the last execution. Only need to find the transaction ID of the first function.
+        // Execute everything between [origTxid, endTxId)
         stmt.setLong(1, endExecId);
         ResultSet endRs = stmt.executeQuery();
         long endTxId = Long.MAX_VALUE;
@@ -146,12 +147,6 @@ public class PostgresRetroReplay {
                 long resTxId = startOrderRs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
                 long resExecId = startOrderRs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
                 long resFuncId = startOrderRs.getLong(ProvenanceBuffer.PROV_FUNCID);
-
-                if (resTxId >= endTxId) {
-                    // Stop at the last transaction Id.
-                    break;
-                }
-
                 String[] resNames = startOrderRs.getString(ProvenanceBuffer.PROV_PROCEDURENAME).split("\\.");
                 String resName = resNames[resNames.length - 1]; // Extract the actual function name.
                 String resSnapshotStr = startOrderRs.getString(ProvenanceBuffer.PROV_TXN_SNAPSHOT);

--- a/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
@@ -142,7 +142,7 @@ public class PostgresRetroReplay {
         // Current transaction ID, execution ID, and function ID.
         long resTxId = -1, resExecId = -1, resFuncId = -1;
 
-        while ((nextCommitTxid > 0) && (resTxId >= endTxId)) {
+        while ((nextCommitTxid > 0) && (resTxId < endTxId)) {
             // Execute all following functions until nextCommitTxid is in the snapshot of that original transaction.
             // If the nextCommitTxid is in the snapshot, then that function needs to start after it commits.
             while (true) {

--- a/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresRetroReplay.java
@@ -18,7 +18,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 public class PostgresRetroReplay {
     private static final Logger logger = LoggerFactory.getLogger(PostgresRetroReplay.class);
 
-    public static Object retroExecuteAll(WorkerContext workerContext, long targetExecID, int replayMode) throws Exception {
+    public static Object retroExecuteAll(WorkerContext workerContext, long targetExecID, long endExecId, int replayMode) throws Exception {
         if (replayMode == ApiaryConfig.ReplayMode.ALL.getValue()) {
             logger.debug("Replay the entire trace!");
         } else if (replayMode == ApiaryConfig.ReplayMode.SELECTIVE.getValue()) {
@@ -133,6 +133,13 @@ public class PostgresRetroReplay {
                 long resTxId = startOrderRs.getLong(ProvenanceBuffer.PROV_APIARY_TRANSACTION_ID);
                 long resExecId = startOrderRs.getLong(ProvenanceBuffer.PROV_EXECUTIONID);
                 long resFuncId = startOrderRs.getLong(ProvenanceBuffer.PROV_FUNCID);
+
+                if (resExecId > endExecId) {
+                    // Stop at the last execution Id.
+                    // TODO: need to stop the outer loop at a proper position as well.
+                    break;
+                }
+
                 String[] resNames = startOrderRs.getString(ProvenanceBuffer.PROV_PROCEDURENAME).split("\\.");
                 String resName = resNames[resNames.length - 1]; // Extract the actual function name.
                 String resSnapshotStr = startOrderRs.getString(ProvenanceBuffer.PROV_TXN_SNAPSHOT);

--- a/src/main/proto/worker.proto
+++ b/src/main/proto/worker.proto
@@ -18,8 +18,9 @@ message ExecuteFunctionRequest {
   int64 functionId = 5;
   int64 senderTimestampNano = 6;
   string service = 7;
-  int64 executionId = 8;  // Unique global IDs for an entire workflow.
+  int64 executionId = 8;  // Unique global IDs for an entire workflow. For retro replay, it means the first execution to be replayed.
   int32 replayMode = 9;  // 0: not replay, 1: replay a single request, 2: replay a request and everything after, 3: selective replay.
+  int64 endExecId = 10;  // Used for retro replay, the last execution ID of the replay.
 }
 
 message ExecuteFunctionReply {

--- a/src/test/java/org/dbos/apiary/MoodleTests.java
+++ b/src/test/java/org/dbos/apiary/MoodleTests.java
@@ -221,7 +221,7 @@ public class MoodleTests {
         // Retroactively execute all.
         // Reset the database and re-execute.
         conn.truncateTable("ForumSubscription", false);
-        resList = client.retroReplay(resExecId, ApiaryConfig.ReplayMode.ALL.getValue()).getIntArray();
+        resList = client.retroReplay(resExecId, resExecId4, ApiaryConfig.ReplayMode.ALL.getValue()).getIntArray();
         assertEquals(1, resList.length);
         assertEquals(123, resList[0]);
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
@@ -318,7 +318,7 @@ public class MoodleTests {
 
         // Reset the table and replay all.
         conn.truncateTable("ForumSubscription", false);
-        int[] retroResList = client.get().retroReplay(resExecId, ApiaryConfig.ReplayMode.ALL.getValue()).getIntArray();
+        int[] retroResList = client.get().retroReplay(resExecId, Long.MAX_VALUE, ApiaryConfig.ReplayMode.ALL.getValue()).getIntArray();
         assertEquals(resList.length, retroResList.length);
         assertTrue(Arrays.equals(resList, retroResList));
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
@@ -336,14 +336,13 @@ public class MoodleTests {
         assert(provBuff != null);
 
         conn.truncateTable("ForumSubscription", false);
-        int[] retroList = client.get().retroReplay(resExecId, ApiaryConfig.ReplayMode.ALL.getValue()).getIntArray();
+        int[] retroList = client.get().retroReplay(resExecId, Long.MAX_VALUE, ApiaryConfig.ReplayMode.ALL.getValue()).getIntArray();
         assertEquals(1, retroList.length);
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
 
         // Retro replay again, but now we enable selective replay.
         conn.truncateTable("ForumSubscription", false);
-        // TODO: what is a better stop strategy?
-        int retroRes = client.get().retroReplay(resExecId, ApiaryConfig.ReplayMode.SELECTIVE.getValue()).getInt();
+        int retroRes = client.get().retroReplay(resExecId, Long.MAX_VALUE, ApiaryConfig.ReplayMode.SELECTIVE.getValue()).getInt();
         assertTrue(retroRes != -1);
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
     }

--- a/src/test/java/org/dbos/apiary/MoodleTests.java
+++ b/src/test/java/org/dbos/apiary/MoodleTests.java
@@ -219,11 +219,10 @@ public class MoodleTests {
         rs.close();
 
         // Retroactively execute all.
-        // Reset the database and re-execute.
+        // Reset the database and re-execute, stop before the last execution.
         conn.truncateTable("ForumSubscription", false);
-        resList = client.retroReplay(resExecId, resExecId4, ApiaryConfig.ReplayMode.ALL.getValue()).getIntArray();
-        assertEquals(1, resList.length);
-        assertEquals(123, resList[0]);
+        res = client.retroReplay(resExecId, resExecId4, ApiaryConfig.ReplayMode.ALL.getValue()).getInt();
+        assertEquals(123, res);
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
     }
 

--- a/src/test/java/org/dbos/apiary/MoodleTests.java
+++ b/src/test/java/org/dbos/apiary/MoodleTests.java
@@ -223,6 +223,13 @@ public class MoodleTests {
         conn.truncateTable("ForumSubscription", false);
         res = client.retroReplay(resExecId, resExecId4, ApiaryConfig.ReplayMode.ALL.getValue()).getInt();
         assertEquals(123, res);
+
+        // Retro replay again, but this time replay the entire trace.
+        conn.truncateTable("ForumSubscription", false);
+        resList = client.retroReplay(resExecId, Long.MAX_VALUE, ApiaryConfig.ReplayMode.ALL.getValue()).getIntArray();
+        assertEquals(1, resList.length);
+        assertEquals(123, resList[0]);
+
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
     }
 

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -257,7 +257,7 @@ public class WordPressTests {
         conn.truncateTable(WPUtil.WP_COMMENTS_TABLE, false);
         conn.truncateTable(WPUtil.WP_POSTMETA_TABLE, false);
 
-        strAryRes = client.get().retroReplay(resExecId, ApiaryConfig.ReplayMode.ALL.getValue()).getStringArray();
+        strAryRes = client.get().retroReplay(resExecId, Long.MAX_VALUE, ApiaryConfig.ReplayMode.ALL.getValue()).getStringArray();
         assertTrue(strAryRes.length > 1);
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
 
@@ -282,7 +282,7 @@ public class WordPressTests {
         conn.truncateTable(WPUtil.WP_COMMENTS_TABLE, false);
         conn.truncateTable(WPUtil.WP_POSTMETA_TABLE, false);
 
-        strAryRes = client.get().retroReplay(resExecId, ApiaryConfig.ReplayMode.ALL.getValue()).getStringArray();
+        strAryRes = client.get().retroReplay(resExecId, Long.MAX_VALUE, ApiaryConfig.ReplayMode.ALL.getValue()).getStringArray();
         assertEquals(1, strAryRes.length);
 
         ApiaryConfig.recordInput = false; // Reset flags.
@@ -295,7 +295,7 @@ public class WordPressTests {
         conn.truncateTable(WPUtil.WP_COMMENTS_TABLE, false);
         conn.truncateTable(WPUtil.WP_POSTMETA_TABLE, false);
 
-        intRes = client.get().retroReplay(resExecId, ApiaryConfig.ReplayMode.SELECTIVE.getValue()).getInt();
+        intRes = client.get().retroReplay(resExecId, Long.MAX_VALUE, ApiaryConfig.ReplayMode.SELECTIVE.getValue()).getInt();
         assertEquals(0, intRes); // Should successfully untrashed the last post.
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);
     }


### PR DESCRIPTION
This PR allows the retro replay to stop right before a given request, by providing an endExecID to the replay function.