### PR TITLE
Retro-replay Improvements

### DIFF
--- a/src/main/java/org/dbos/apiary/benchmarks/retro/MoodleBenchmark.java
+++ b/src/main/java/org/dbos/apiary/benchmarks/retro/MoodleBenchmark.java
@@ -3,7 +3,6 @@ package org.dbos.apiary.benchmarks.retro;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.dbos.apiary.benchmarks.RetroBenchmark;
 import org.dbos.apiary.client.ApiaryWorkerClient;
-import org.dbos.apiary.function.FunctionOutput;
 import org.dbos.apiary.function.ProvenanceBuffer;
 import org.dbos.apiary.postgres.PostgresConnection;
 import org.dbos.apiary.procedures.postgres.moodle.MDLFetchSubscribers;
@@ -97,14 +96,16 @@ public class MoodleBenchmark {
         if ((bugFix != null) && bugFix.equalsIgnoreCase("subscribe")) {
             logger.info("Use Moodle bug fix: {}", MDLSubscribeTxn.class.getName());
             // Use the bug fix: transactional version.
-            apiaryWorker.registerFunction("MDLIsSubscribed", ApiaryConfig.postgres, MDLSubscribeTxn::new, true);
+            apiaryWorker.registerFunction("MDLIsSubscribed", ApiaryConfig.postgres, MDLSubscribeTxn::new, true, false);
         } else {
             // The buggy version.
             logger.info("Use Moodle buggy version: {}", MDLIsSubscribed.class.getName());
-            apiaryWorker.registerFunction("MDLIsSubscribed", ApiaryConfig.postgres, MDLIsSubscribed::new);
+            apiaryWorker.registerFunction("MDLIsSubscribed", ApiaryConfig.postgres, MDLIsSubscribed::new, false, true);
+            apiaryWorker.registerFunctionSet("MDLIsSubscribed", "MDLIsSubscribed", "MDLForumInsert");
         }
-        apiaryWorker.registerFunction("MDLForumInsert", ApiaryConfig.postgres, MDLForumInsert::new);
-        apiaryWorker.registerFunction("MDLFetchSubscribers", ApiaryConfig.postgres, MDLFetchSubscribers::new);
+        apiaryWorker.registerFunction("MDLForumInsert", ApiaryConfig.postgres, MDLForumInsert::new, false, false);
+        apiaryWorker.registerFunction("MDLFetchSubscribers", ApiaryConfig.postgres, MDLFetchSubscribers::new, false, true);
+
         apiaryWorker.startServing();
 
         if (retroMode > 0) {

--- a/src/main/java/org/dbos/apiary/benchmarks/retro/WordPressBenchmark.java
+++ b/src/main/java/org/dbos/apiary/benchmarks/retro/WordPressBenchmark.java
@@ -183,25 +183,27 @@ public class WordPressBenchmark {
         apiaryWorker.registerConnection(ApiaryConfig.postgres, pgConn);
 
         // Register all functions.
-        apiaryWorker.registerFunction(WPUtil.FUNC_ADDPOST, ApiaryConfig.postgres, WPAddPost::new);
-        apiaryWorker.registerFunction(WPUtil.FUNC_ADDCOMMENT, ApiaryConfig.postgres, WPAddComment::new);
-        apiaryWorker.registerFunction(WPUtil.FUNC_GETPOSTCOMMENTS, ApiaryConfig.postgres, WPGetPostComments::new);
-        apiaryWorker.registerFunction(WPUtil.FUNC_TRASHPOST, ApiaryConfig.postgres, WPTrashPost::new);
-        apiaryWorker.registerFunction(WPUtil.FUNC_TRASHCOMMENTS, ApiaryConfig.postgres, WPTrashComments::new);
-        apiaryWorker.registerFunction(WPUtil.FUNC_UNTRASHPOST, ApiaryConfig.postgres, WPUntrashPost::new);
-        apiaryWorker.registerFunction(WPUtil.FUNC_COMMENTSTATUS, ApiaryConfig.postgres, WPCheckCommentStatus::new);
-        apiaryWorker.registerFunction(WPUtil.FUNC_GETOPTION, ApiaryConfig.postgres, WPGetOption::new);
-        apiaryWorker.registerFunction(WPUtil.FUNC_OPTIONEXISTS, ApiaryConfig.postgres, WPOptionExists::new);
-        apiaryWorker.registerFunction(WPUtil.FUNC_INSERTOPTION, ApiaryConfig.postgres, WPInsertOption::new);
+        apiaryWorker.registerFunction(WPUtil.FUNC_ADDPOST, ApiaryConfig.postgres, WPAddPost::new, false, false);
+        apiaryWorker.registerFunction(WPUtil.FUNC_ADDCOMMENT, ApiaryConfig.postgres, WPAddComment::new, false, false);
+        apiaryWorker.registerFunction(WPUtil.FUNC_GETPOSTCOMMENTS, ApiaryConfig.postgres, WPGetPostComments::new, false, true);
+        apiaryWorker.registerFunction(WPUtil.FUNC_TRASHPOST, ApiaryConfig.postgres, WPTrashPost::new, false, false);
+        apiaryWorker.registerFunction(WPUtil.FUNC_TRASHCOMMENTS, ApiaryConfig.postgres, WPTrashComments::new, false, false);
+        apiaryWorker.registerFunction(WPUtil.FUNC_UNTRASHPOST, ApiaryConfig.postgres, WPUntrashPost::new, false, false);
+        apiaryWorker.registerFunction(WPUtil.FUNC_COMMENTSTATUS, ApiaryConfig.postgres, WPCheckCommentStatus::new, false, true);
+        apiaryWorker.registerFunction(WPUtil.FUNC_GETOPTION, ApiaryConfig.postgres, WPGetOption::new, false, true);
+        apiaryWorker.registerFunction(WPUtil.FUNC_OPTIONEXISTS, ApiaryConfig.postgres, WPOptionExists::new, false, true);
+        apiaryWorker.registerFunction(WPUtil.FUNC_INSERTOPTION, ApiaryConfig.postgres, WPInsertOption::new, false, false);
+        apiaryWorker.registerFunctionSet(WPUtil.FUNC_TRASHPOST, WPUtil.FUNC_TRASHPOST, WPUtil.FUNC_TRASHCOMMENTS);
+        apiaryWorker.registerFunctionSet(WPUtil.FUNC_OPTIONEXISTS, WPUtil.FUNC_OPTIONEXISTS, WPUtil.FUNC_INSERTOPTION);
 
         if (bugFix != null) {
             // The fixed version.
             if (bugFix.equalsIgnoreCase("comment")) {
                 logger.info("Use WordPress bug fix for comment: {}", WPAddCommentFixed.class.getName());
-                apiaryWorker.registerFunction(WPUtil.FUNC_ADDCOMMENT, ApiaryConfig.postgres, WPAddCommentFixed::new, true);
+                apiaryWorker.registerFunction(WPUtil.FUNC_ADDCOMMENT, ApiaryConfig.postgres, WPAddCommentFixed::new, true, false);
             } else if (bugFix.equalsIgnoreCase("option")) {
                 logger.info("Use WordPress bug fix for option: {}", WPInsertOptionFixed.class.getName());
-                apiaryWorker.registerFunction(WPUtil.FUNC_INSERTOPTION, ApiaryConfig.postgres, WPInsertOptionFixed::new, true);
+                apiaryWorker.registerFunction(WPUtil.FUNC_INSERTOPTION, ApiaryConfig.postgres, WPInsertOptionFixed::new, true, false);
             }
         } else {
             // The buggy version.

--- a/src/main/java/org/dbos/apiary/function/WorkerContext.java
+++ b/src/main/java/org/dbos/apiary/function/WorkerContext.java
@@ -70,8 +70,13 @@ public class WorkerContext {
         functionSets.put(firstFunc, List.of(funcNames));
     }
 
+    // Try to find the function set info. If not found, return the first function name.
     public List<String> getFunctionSet(String firstFunc) {
-        return functionSets.get(firstFunc);
+        if (functionSets.containsKey(firstFunc)) {
+            return functionSets.get(firstFunc);
+        }
+        // Return the first function.
+        return List.of(firstFunc);
     }
 
     public boolean getFunctionSetReadOnly(String firstFunc) {

--- a/src/main/java/org/dbos/apiary/function/WorkerContext.java
+++ b/src/main/java/org/dbos/apiary/function/WorkerContext.java
@@ -7,6 +7,7 @@ import org.dbos.apiary.utilities.ApiaryConfig;
 import org.dbos.apiary.utilities.Utilities;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -17,6 +18,13 @@ public class WorkerContext {
 
     // Record a mapping between the old function name and its new class name. Used by retroactive programming.
     private final Map<String, String> retroFunctions = new HashMap<>();
+
+    // Record a mapping between the name of the first function and the set of functions in a workflow. Used by retroactive programming.
+    private final Map<String, List<String>> functionSets = new HashMap<>();
+
+    // Record if a set of functions is read-only, the key is the first function name.
+    private final Map<String, Boolean> functionSetReadOnly = new HashMap<>();
+
     private ApiaryConnection primaryConnection = null;
     private String primaryConnectionType;
 
@@ -54,6 +62,24 @@ public class WorkerContext {
             assert (func != null);
             String actualName = Utilities.getFunctionClassName(func);
             retroFunctions.put(name, actualName);
+        }
+    }
+
+    public void registerFunctionSet(String firstFunc, boolean isReadOnly, String[] funcNames) {
+        functionSets.put(firstFunc, List.of(funcNames));
+        functionSetReadOnly.put(firstFunc, isReadOnly);
+    }
+
+    public List<String> getFunctionSet(String firstFunc) {
+        return functionSets.get(firstFunc);
+    }
+
+    public boolean getFunctionSetReadOnly(String firstFunc) {
+        if (functionSetReadOnly.containsKey(firstFunc)) {
+            return functionSetReadOnly.get(firstFunc);
+        } else {
+            // Conservatively, assume it contains writes.
+            return false;
         }
     }
 

--- a/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
+++ b/src/main/java/org/dbos/apiary/postgres/PostgresConnection.java
@@ -347,7 +347,8 @@ public class PostgresConnection implements ApiaryConnection {
                     if (innerException instanceof PSQLException) {
                         PSQLException p = (PSQLException) innerException;
                         errorMsg = p.getMessage();
-                        if (p.getSQLState().equals(PSQLState.SERIALIZATION_FAILURE.getState())) {
+                        // Only retry under retro mode. We should not have serialization error under faithful replay.
+                        if (p.getSQLState().equals(PSQLState.SERIALIZATION_FAILURE.getState()) && workerContext.hasRetroFunctions()) {
                             recordTransactionInfo(workerContext, ctxt, startTime, actualName, ProvenanceBuffer.PROV_STATUS_FAIL_RECOVERABLE);
                             logger.debug("Serialization failure during replay, will retry: {}", errorMsg);
                             continue;  // Retry.

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -93,6 +93,16 @@ public class ApiaryWorker {
         workerContext.registerFunction(name, type, function, isRetro);
     }
 
+    /**
+     * Register a list of a functions as an execution set -- they will be executed to serve one request. Mostly used for retroactive analysis.
+     * @param firstFunc     Name of the first function.
+     * @param isReadOnly    Is this set readOnly?
+     * @param funcNames     List of functions in the set, including the first function.
+     */
+    public void registerFunctionSet(String firstFunc, boolean isReadOnly, String... funcNames) {
+        workerContext.registerFunctionSet(firstFunc, isReadOnly, funcNames);
+    }
+
     public void startServing() {
         garbageCollectorThread = new Thread(this::garbageCollectorThread);
         garbageCollectorThread.start();

--- a/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
+++ b/src/main/java/org/dbos/apiary/worker/ApiaryWorker.java
@@ -89,18 +89,17 @@ public class ApiaryWorker {
         workerContext.registerFunction(name, type, function);
     }
 
-    public void registerFunction(String name, String type, Callable<ApiaryFunction> function, boolean isRetro) {
-        workerContext.registerFunction(name, type, function, isRetro);
+    public void registerFunction(String name, String type, Callable<ApiaryFunction> function, boolean isRetro, boolean isReadOnly) {
+        workerContext.registerFunction(name, type, function, isRetro, isReadOnly);
     }
 
     /**
      * Register a list of a functions as an execution set -- they will be executed to serve one request. Mostly used for retroactive analysis.
      * @param firstFunc     Name of the first function.
-     * @param isReadOnly    Is this set readOnly?
      * @param funcNames     List of functions in the set, including the first function.
      */
-    public void registerFunctionSet(String firstFunc, boolean isReadOnly, String... funcNames) {
-        workerContext.registerFunctionSet(firstFunc, isReadOnly, funcNames);
+    public void registerFunctionSet(String firstFunc, String... funcNames) {
+        workerContext.registerFunctionSet(firstFunc, funcNames);
     }
 
     public void startServing() {

--- a/src/test/java/org/dbos/apiary/MoodleTests.java
+++ b/src/test/java/org/dbos/apiary/MoodleTests.java
@@ -333,10 +333,10 @@ public class MoodleTests {
         apiaryWorker.shutdown(); // Stop the existing worker.
         apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
         apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);
-        apiaryWorker.registerFunction("MDLIsSubscribed", ApiaryConfig.postgres, MDLSubscribeTxn::new, true);  // Register the new one.
+        apiaryWorker.registerFunction("MDLIsSubscribed", ApiaryConfig.postgres, MDLSubscribeTxn::new, true, false);  // Register the new one.
         // The old one.
-        apiaryWorker.registerFunction("MDLForumInsert", ApiaryConfig.postgres, MDLForumInsert::new);
-        apiaryWorker.registerFunction("MDLFetchSubscribers", ApiaryConfig.postgres, MDLFetchSubscribers::new);
+        apiaryWorker.registerFunction("MDLForumInsert", ApiaryConfig.postgres, MDLForumInsert::new, false, false);
+        apiaryWorker.registerFunction("MDLFetchSubscribers", ApiaryConfig.postgres, MDLFetchSubscribers::new, false, true);
         apiaryWorker.startServing();
 
         provBuff = apiaryWorker.workerContext.provBuff;

--- a/src/test/java/org/dbos/apiary/MoodleTests.java
+++ b/src/test/java/org/dbos/apiary/MoodleTests.java
@@ -337,6 +337,9 @@ public class MoodleTests {
         // The old one.
         apiaryWorker.registerFunction("MDLForumInsert", ApiaryConfig.postgres, MDLForumInsert::new, false, false);
         apiaryWorker.registerFunction("MDLFetchSubscribers", ApiaryConfig.postgres, MDLFetchSubscribers::new, false, true);
+
+        // No need to register function set, because we have a single function now.
+        // apiaryWorker.registerFunctionSet("MDLIsSubscribed", "MDLIsSubscribed", "MDLForumInsert");
         apiaryWorker.startServing();
 
         provBuff = apiaryWorker.workerContext.provBuff;

--- a/src/test/java/org/dbos/apiary/WordPressTests.java
+++ b/src/test/java/org/dbos/apiary/WordPressTests.java
@@ -271,14 +271,15 @@ public class WordPressTests {
         apiaryWorker.shutdown();
         apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
         apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);
-        apiaryWorker.registerFunction("WPAddPost", ApiaryConfig.postgres, WPAddPost::new);
+        apiaryWorker.registerFunction("WPAddPost", ApiaryConfig.postgres, WPAddPost::new, false, false);
         // Use the new code.
-        apiaryWorker.registerFunction("WPAddComment", ApiaryConfig.postgres, WPAddCommentFixed::new, true);
-        apiaryWorker.registerFunction("WPGetPostComments", ApiaryConfig.postgres, WPGetPostComments::new);
-        apiaryWorker.registerFunction("WPTrashPost", ApiaryConfig.postgres, WPTrashPost::new);
-        apiaryWorker.registerFunction("WPTrashComments", ApiaryConfig.postgres, WPTrashComments::new);
-        apiaryWorker.registerFunction("WPUntrashPost", ApiaryConfig.postgres, WPUntrashPost::new);
-        apiaryWorker.registerFunction("WPCheckCommentStatus", ApiaryConfig.postgres, WPCheckCommentStatus::new);
+        apiaryWorker.registerFunction("WPAddComment", ApiaryConfig.postgres, WPAddCommentFixed::new, true, false);
+        apiaryWorker.registerFunction("WPGetPostComments", ApiaryConfig.postgres, WPGetPostComments::new, false, true);
+        apiaryWorker.registerFunction("WPTrashPost", ApiaryConfig.postgres, WPTrashPost::new, false, false);
+        apiaryWorker.registerFunction("WPTrashComments", ApiaryConfig.postgres, WPTrashComments::new, false, false);
+        apiaryWorker.registerFunction("WPUntrashPost", ApiaryConfig.postgres, WPUntrashPost::new, false, false);
+        apiaryWorker.registerFunction("WPCheckCommentStatus", ApiaryConfig.postgres, WPCheckCommentStatus::new, false, true);
+        apiaryWorker.registerFunctionSet(WPUtil.FUNC_TRASHPOST, WPUtil.FUNC_TRASHPOST, WPUtil.FUNC_TRASHCOMMENTS);
         apiaryWorker.startServing();
 
         provBuff = apiaryWorker.workerContext.provBuff;
@@ -342,9 +343,9 @@ public class WordPressTests {
 
         apiaryWorker = new ApiaryWorker(new ApiaryNaiveScheduler(), 4, ApiaryConfig.postgres, ApiaryConfig.provenanceDefaultAddress);
         apiaryWorker.registerConnection(ApiaryConfig.postgres, conn);
-        apiaryWorker.registerFunction("WPGetOption", ApiaryConfig.postgres, WPGetOption::new);
-        apiaryWorker.registerFunction("WPOptionExists", ApiaryConfig.postgres, WPOptionExists::new);
-        apiaryWorker.registerFunction("WPInsertOption", ApiaryConfig.postgres, WPInsertOption::new);
+        apiaryWorker.registerFunction("WPGetOption", ApiaryConfig.postgres, WPGetOption::new, false, true);
+        apiaryWorker.registerFunction("WPOptionExists", ApiaryConfig.postgres, WPOptionExists::new, false, true);
+        apiaryWorker.registerFunction("WPInsertOption", ApiaryConfig.postgres, WPInsertOption::new, false, false);
         apiaryWorker.startServing();
 
         ProvenanceBuffer provBuff = apiaryWorker.workerContext.provBuff;
@@ -439,7 +440,8 @@ public class WordPressTests {
 
         // Register the new function and retro replay all.
         conn.truncateTable(WPUtil.WP_OPTIONS_TABLE, false);
-        apiaryWorker.registerFunction("WPInsertOption", ApiaryConfig.postgres, WPInsertOptionFixed::new, true);
+        apiaryWorker.registerFunction(WPUtil.FUNC_INSERTOPTION, ApiaryConfig.postgres, WPInsertOptionFixed::new, true, false);
+        apiaryWorker.registerFunctionSet(WPUtil.FUNC_OPTIONEXISTS, WPUtil.FUNC_OPTIONEXISTS, WPUtil.FUNC_INSERTOPTION);
 
         resStr = client.get().retroReplay(resExecId, Long.MAX_VALUE, ApiaryConfig.ReplayMode.ALL.getValue()).getString();
         Thread.sleep(ProvenanceBuffer.exportInterval * 2);


### PR DESCRIPTION
This PR fixes several issues in retro-replay.
- Only retry serialization error if we have new functions. Because faithful replay should never have this issue, as we only replay committed transactions and the unrecoverable failed ones.
- Improve performance of selective replay: record function set and read-only information during function registration, so it's a one-time cost. Then only run one query to check accessed tables per execution ID. So we avoid extra DB queries per skipFunc check.

Now selective replay can be much faster than replaying all because we can skip executions without much overhead.